### PR TITLE
[APP-8514] Optional live/offline widgets user can pass in to confirmation screen  

### DIFF
--- a/example/hotspot_provisioning/lib/offline_screen.dart
+++ b/example/hotspot_provisioning/lib/offline_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class OfflineScreen extends StatelessWidget {
+  final void Function() onPressed;
+  const OfflineScreen({super.key, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Could not connect to the robot.'),
+            const SizedBox(height: 16),
+            const Icon(Icons.error, color: Colors.red, size: 48),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onPressed,
+              child: const Text('Try Again'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/hotspot_provisioning/lib/online_screen.dart
+++ b/example/hotspot_provisioning/lib/online_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class OnlineScreen extends StatelessWidget {
+  final void Function() onPressed;
+  const OnlineScreen({super.key, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Robot is online! I passed this screen in the onlineBuilder'),
+            const SizedBox(height: 16),
+            const Icon(Icons.check_circle, color: Colors.green, size: 48),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onPressed,
+              child: const Text('Done'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/hotspot_provisioning/lib/start_screen.dart
+++ b/example/hotspot_provisioning/lib/start_screen.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:viam_flutter_hotspot_provisioning_widget/viam_flutter_hotspot_provisioning_widget.dart';
+import 'offline_screen.dart';
+import 'online_screen.dart';
 import 'consts.dart';
 
 class StartScreen extends StatefulWidget {
@@ -71,6 +73,12 @@ class _StartScreenState extends State<StartScreen> {
             mainPart: mainPart,
             hotspotPrefix: Consts.hotspotPrefix,
             hotspotPassword: Consts.hotspotPassword,
+            onlineBuilder: (navContext) {
+              return OnlineScreen(onPressed: () => Navigator.of(navContext).pop());
+            },
+            offlineBuilder: (navContext) {
+              return OfflineScreen(onPressed: () => Navigator.of(navContext).pop());
+            },
           ),
         ));
       }

--- a/lib/src/confirmation_screen.dart
+++ b/lib/src/confirmation_screen.dart
@@ -119,31 +119,11 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
           widget.onlineBuilder != null
               ? widget.onlineBuilder!(context)
               : Expanded(
-                  child: Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const Text('Robot is online'),
-                        const Icon(Icons.check_circle, color: Colors.green),
-                      ],
-                    ),
-                  ),
-                ),
+                  child: RobotOnlineWidget(
+                  robot: widget.robot,
+                )),
         if (_robotStatus == RobotStatus.offline)
-          widget.offlineBuilder != null
-              ? widget.offlineBuilder!(context)
-              : Expanded(
-                  child: Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const Text('Robot is offline. Connection failed'),
-                        const Icon(Icons.error, color: Colors.red),
-                        // TOOD: take the user back to reconnect flow??
-                      ],
-                    ),
-                  ),
-                ),
+          widget.offlineBuilder != null ? widget.offlineBuilder!(context) : const Expanded(child: RobotOfflineWidget()),
         if (_robotStatus == RobotStatus.loading)
           Expanded(
             child: Center(

--- a/lib/src/confirmation_screen.dart
+++ b/lib/src/confirmation_screen.dart
@@ -3,11 +3,14 @@ part of '../../viam_flutter_hotspot_provisioning_widget.dart';
 enum RobotStatus { online, offline, loading }
 
 class ConfirmationScreen extends StatefulWidget {
-  const ConfirmationScreen({super.key, required this.robot, required this.viam, required this.mainPart});
+  const ConfirmationScreen(
+      {super.key, required this.robot, required this.viam, required this.mainPart, this.onlineBuilder, this.offlineBuilder});
 
   final Viam viam;
   final Robot robot;
   final RobotPart mainPart;
+  final Widget Function(BuildContext context)? onlineBuilder;
+  final Widget Function(BuildContext context)? offlineBuilder;
 
   @override
   State<ConfirmationScreen> createState() => _ConfirmationScreenState();
@@ -60,13 +63,14 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
       final newRobotStatus = await calculateRobotStatus(reloadedRobot);
       debugPrint('Robot status: $newRobotStatus, name: ${reloadedRobot.name}');
       if (newRobotStatus == RobotStatus.online) {
-        // TODO: before we had goToRobotScreen();, decide if we should do something here.
-        // a callback that they can choose to do something with --> the flow will do something with it
         _timer?.cancel();
+        // TODO: show a robot is online screen here?
       }
-      setState(() {
-        _robotStatus = newRobotStatus;
-      });
+      if (mounted) {
+        setState(() {
+          _robotStatus = newRobotStatus;
+        });
+      }
     } catch (e) {
       // if an error, that means we still lack network connection
       debugPrint('Error getting robot status ${e.toString()}');
@@ -112,31 +116,34 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
     return Column(
       children: [
         if (_robotStatus == RobotStatus.online)
-          Expanded(
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('Robot is online'),
-                  const Icon(Icons.check_circle, color: Colors.green),
-                  // TODO: show a robot is online screen here?
-                ],
-              ),
-            ),
-          ),
+          widget.onlineBuilder != null
+              ? widget.onlineBuilder!(context)
+              : Expanded(
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Text('Robot is online'),
+                        const Icon(Icons.check_circle, color: Colors.green),
+                      ],
+                    ),
+                  ),
+                ),
         if (_robotStatus == RobotStatus.offline)
-          Expanded(
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('Robot is offline. Connection failed'),
-                  const Icon(Icons.error, color: Colors.red),
-                  // TODO: show error screen that takes user back to reconnect flow
-                ],
-              ),
-            ),
-          ),
+          widget.offlineBuilder != null
+              ? widget.offlineBuilder!(context)
+              : Expanded(
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Text('Robot is offline. Connection failed'),
+                        const Icon(Icons.error, color: Colors.red),
+                        // TOOD: take the user back to reconnect flow??
+                      ],
+                    ),
+                  ),
+                ),
         if (_robotStatus == RobotStatus.loading)
           Expanded(
             child: Center(

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -6,6 +6,8 @@ class HotspotProvisioningFlow extends StatefulWidget {
   final RobotPart mainPart;
   final String hotspotPrefix;
   final String hotspotPassword;
+  final Widget Function(BuildContext context)? onlineBuilder;
+  final Widget Function(BuildContext context)? offlineBuilder;
 
   const HotspotProvisioningFlow({
     super.key,
@@ -14,6 +16,8 @@ class HotspotProvisioningFlow extends StatefulWidget {
     required this.mainPart,
     required this.hotspotPrefix,
     required this.hotspotPassword,
+    this.onlineBuilder,
+    this.offlineBuilder,
   });
 
   @override
@@ -174,6 +178,8 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
                   robot: widget.robot,
                   viam: widget.viam,
                   mainPart: widget.mainPart,
+                  onlineBuilder: widget.onlineBuilder,
+                  offlineBuilder: widget.offlineBuilder,
                 )
               ],
             ),

--- a/lib/src/widgets/robot_offline_widget.dart
+++ b/lib/src/widgets/robot_offline_widget.dart
@@ -1,0 +1,15 @@
+part of '../../viam_flutter_hotspot_provisioning_widget.dart';
+
+class RobotOfflineWidget extends StatelessWidget {
+  const RobotOfflineWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const NoContentWidget(
+      icon: Icon(Icons.error, color: Colors.red),
+      titleString: 'Robot is offline',
+      bodyString: 'Connection failed',
+      // TODO: decide if we want to reconnect here?
+    );
+  }
+}

--- a/lib/src/widgets/robot_online_widget.dart
+++ b/lib/src/widgets/robot_online_widget.dart
@@ -1,0 +1,16 @@
+part of '../../viam_flutter_hotspot_provisioning_widget.dart';
+
+class RobotOnlineWidget extends StatelessWidget {
+  final Robot robot;
+
+  const RobotOnlineWidget({super.key, required this.robot});
+
+  @override
+  Widget build(BuildContext context) {
+    return NoContentWidget(
+      icon: const Icon(Icons.check_circle, color: Colors.green, size: 40),
+      titleString: 'Connected!',
+      bodyString: '${robot.name} is online and ready.',
+    );
+  }
+}

--- a/lib/viam_flutter_hotspot_provisioning_widget.dart
+++ b/lib/viam_flutter_hotspot_provisioning_widget.dart
@@ -29,3 +29,5 @@ part 'src/widgets/no_content_widget.dart';
 part 'src/widgets/pill_button.dart';
 part 'src/widgets/primary_button.dart';
 part 'src/widgets/provisioning_list_item.dart';
+part 'src/widgets/robot_online_widget.dart';
+part 'src/widgets/robot_offline_widget.dart';


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8514) - This PR introduces onlineBuilder and offlineBuilder functions to the hotspot provisioning flow, allowing for custom UI when the robot comes online or fails to connect. This way the user can choose to pass in these screens if they want.

this is how it behaves when the user passes in their own screen when the robot gets online:

https://github.com/user-attachments/assets/6fcc041d-4257-4070-9993-d385c2beecdb

this is how it behaves when the user passes in their own screen when the robot fails to get onlie:

https://github.com/user-attachments/assets/14f97e2e-4a00-4fb4-8e0b-36eb18471cd7


And finally if the user does not pass in any screens they are given this default screen:

https://github.com/user-attachments/assets/c6acdd8d-8408-4f6b-9aa0-d9206c9aa4d3



and if the connection fails:
<img width="350" alt="Screenshot 2025-06-10 at 4 50 08 PM" src="https://github.com/user-attachments/assets/80de3001-bf82-4791-8faa-4f29833bad5f">

