### PR TITLE
[APP-8321] - Handle time out screen

### DIFF
--- a/lib/src/confirmation_screen.dart
+++ b/lib/src/confirmation_screen.dart
@@ -64,7 +64,6 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
       debugPrint('Robot status: $newRobotStatus, name: ${reloadedRobot.name}');
       if (newRobotStatus == RobotStatus.online) {
         _timer?.cancel();
-        // TODO: show a robot is online screen here?
       }
       if (mounted) {
         setState(() {
@@ -86,58 +85,26 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
     return RobotStatus.loading;
   }
 
-  NoContentWidget showLoadingScreen() {
-    if (_secondsLoading < provisioningTimeoutSeconds) {
-      return NoContentWidget(
-        titleString: _secondsLoading < provisioningStillWaitingSeconds ? "Setting up device..." : "Still trying...",
-        bodyString: _secondsLoading < provisioningStillWaitingSeconds
-            ? null
-            : "Please keep this screen open. We'll keep trying to connect for a few more minutes.",
-      );
-    }
-    return NoContentWidget(
-      icon: Icon(Icons.highlight_off, color: Color(0xFFF86061)),
-      titleString: "Connection failed",
-      bodyString: "Unable to connect to your device's Wi-Fi network",
-      button: PillButton(
-        buttonString: "Try again",
-        iconData: Icons.refresh,
-        onPressed: () {
-          Navigator.of(context).pop();
-          // add a callback that allows the user to fill in what they want to do / where they want to go.
-          // TODO: instead of popping, we should navigate to the reconnect flow when a user wants to try and reconnect after a failed provision attempt.
-        },
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        if (_robotStatus == RobotStatus.online)
-          widget.onlineBuilder != null
-              ? widget.onlineBuilder!(context)
-              : Expanded(
-                  child: RobotOnlineWidget(
-                  robot: widget.robot,
-                )),
-        if (_robotStatus == RobotStatus.offline)
-          widget.offlineBuilder != null ? widget.offlineBuilder!(context) : const Expanded(child: RobotOfflineWidget()),
-        if (_robotStatus == RobotStatus.loading)
-          Expanded(
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('Robot is loading'),
-                  const SizedBox(height: 24),
-                  showLoadingScreen(),
-                ],
-              ),
-            ),
-          ),
-      ],
-    );
+    if (_robotStatus == RobotStatus.online) {
+      return widget.onlineBuilder != null
+          ? widget.onlineBuilder!(context)
+          : Expanded(
+              child: RobotOnlineWidget(
+              robot: widget.robot,
+            ));
+    } else if (_robotStatus == RobotStatus.offline) {
+      return widget.offlineBuilder != null ? widget.offlineBuilder!(context) : const Expanded(child: RobotOfflineWidget());
+    } else if (_secondsLoading >= provisioningTimeoutSeconds) {
+      return widget.offlineBuilder != null ? widget.offlineBuilder!(context) : const Expanded(child: RobotOfflineWidget());
+    } else {
+      return Expanded(
+        child: RobotLoadingWidget(
+          secondsLoading: _secondsLoading,
+          provisioningStillWaitingSeconds: provisioningStillWaitingSeconds,
+        ),
+      );
+    }
   }
 }

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -121,7 +121,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     }
 
     return AppBar(
-      title: Text(title, style: const TextStyle(color: Colors.black)),
+      title: Text(title, style: const TextStyle(color: Colors.black, fontSize: 18.0, fontWeight: FontWeight.w500)),
       backgroundColor: Colors.white,
       elevation: 0,
       actions: actions,

--- a/lib/src/widgets/no_content_widget.dart
+++ b/lib/src/widgets/no_content_widget.dart
@@ -30,7 +30,7 @@ class NoContentWidget extends StatelessWidget {
             titleString,
             style: TextStyle(
               fontSize: 16.0,
-              color: Color(0xFFF7F7F8),
+              color: Colors.black,
               fontWeight: FontWeight.bold,
             ),
           ),

--- a/lib/src/widgets/robot_loading_widget.dart
+++ b/lib/src/widgets/robot_loading_widget.dart
@@ -1,0 +1,22 @@
+part of '../../viam_flutter_hotspot_provisioning_widget.dart';
+
+class RobotLoadingWidget extends StatelessWidget {
+  final int secondsLoading;
+  final int provisioningStillWaitingSeconds;
+
+  const RobotLoadingWidget({
+    super.key,
+    required this.secondsLoading,
+    required this.provisioningStillWaitingSeconds,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return NoContentWidget(
+      titleString: secondsLoading < provisioningStillWaitingSeconds ? "Setting up device..." : "Still trying...",
+      bodyString: secondsLoading < provisioningStillWaitingSeconds
+          ? null
+          : "Please keep this screen open. We'll keep trying to connect for a few more minutes.",
+    );
+  }
+}

--- a/lib/viam_flutter_hotspot_provisioning_widget.dart
+++ b/lib/viam_flutter_hotspot_provisioning_widget.dart
@@ -29,5 +29,6 @@ part 'src/widgets/no_content_widget.dart';
 part 'src/widgets/pill_button.dart';
 part 'src/widgets/primary_button.dart';
 part 'src/widgets/provisioning_list_item.dart';
+part 'src/widgets/robot_loading_widget.dart';
 part 'src/widgets/robot_online_widget.dart';
 part 'src/widgets/robot_offline_widget.dart';


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8321) - This PR cleans up the loading and timeout screen during provisioning. Now, if the user times-out they are just shown the same offline screen. This is because we don't want to be too opinionated here. Timing-out and the machine being offline are the same error in this case. If we want to change this later on we can. 

here is a video of what the screen would show after timing-out:

https://github.com/user-attachments/assets/9f7e5aee-c44a-4e6b-8348-c730701d2870

