### PR TITLE
[APP-8634] Don't allow private network password to be sent as empty

### DIFF
--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -33,7 +33,9 @@ class PasswordInputViewModel extends ChangeNotifier {
 
   bool get areCredentialsEntered {
     if (_network != null) {
-      return true;
+      // For public networks, credentials are entered even with empty password
+      // For private networks, password must be non-empty
+      return isPublicNetwork(_network!) || _passwordController.text.isNotEmpty;
     }
     return _ssidController.text.isNotEmpty;
   }

--- a/lib/src/screens/password_input.dart/widgets/password_input_screen.dart
+++ b/lib/src/screens/password_input.dart/widgets/password_input_screen.dart
@@ -6,7 +6,9 @@ class PasswordInputScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final viewModel = context.watch<PasswordInputViewModel>();
-    final bool canSubmit = viewModel.network != null || viewModel.ssidController.text.isNotEmpty;
+    // final bool canSubmit = viewModel.network != null || viewModel.ssidController.text.isNotEmpty;
+    final bool canSubmit = viewModel.areCredentialsEntered;
+
     final bool isPublicNetwork = viewModel.network != null && viewModel.isPublicNetwork(viewModel.network!);
 
     return GestureDetector(


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8634) - When a password is private we should not let a user submit an empty string. If a password is public we can allow this. 