### PR TITLE
[APP-8581] Fix spacing on connect to device screen

### DIFF
--- a/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
@@ -91,10 +91,11 @@ class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen>
                         padding: const EdgeInsets.only(left: 14.0, bottom: 20.0),
                         child: Column(
                           children: [
-                            Text("You are connected to the device's hotspot.", style: listStyle),
                             Row(
                               children: [
                                 Icon(Icons.check_circle, color: Colors.green),
+                                const SizedBox(width: 8.0),
+                                Text("You are connected to the device's hotspot.", style: listStyle),
                                 Spacer(),
                               ],
                             ),


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8581) - Quick fix between the spacing of the check icon and the text. Now it all fits in one line: 

<img width="300" alt="IMG_3084" src="https://github.com/user-attachments/assets/c36d23e8-1aba-49fa-a608-0de40b729860">


