### PR TITLE
[APP-8661] Hotspot provisioning widget doesn't work on android pt1

### DIFF
--- a/example/hotspot_provisioning/android/app/build.gradle
+++ b/example/hotspot_provisioning/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId = "com.example.viam_example_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 29
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/example/hotspot_provisioning/android/app/build.gradle
+++ b/example/hotspot_provisioning/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId = "com.example.viam_example_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 29
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/example/hotspot_provisioning/android/app/src/debug/AndroidManifest.xml
+++ b/example/hotspot_provisioning/android/app/src/debug/AndroidManifest.xml
@@ -4,6 +4,4 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 </manifest>

--- a/example/hotspot_provisioning/android/app/src/main/AndroidManifest.xml
+++ b/example/hotspot_provisioning/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools">
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/example/hotspot_provisioning/android/app/src/main/AndroidManifest.xml
+++ b/example/hotspot_provisioning/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,15 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application
-        android:label="Bluetooth"
+        android:label="Hotspot Provisioning Example"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/hotspot_provisioning/android/app/src/profile/AndroidManifest.xml
+++ b/example/hotspot_provisioning/android/app/src/profile/AndroidManifest.xml
@@ -4,6 +4,4 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 </manifest>

--- a/example/hotspot_provisioning/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/hotspot_provisioning/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/example/hotspot_provisioning/android/settings.gradle
+++ b/example/hotspot_provisioning/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.3.2" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -63,6 +63,10 @@ class PasswordInputViewModel extends ChangeNotifier {
     _setObscureText(!_obscureText);
   }
 
+  void clearPassword() {
+    _passwordController.clear();
+  }
+
   set network(NetworkInfo? network) {
     _setNetwork(network);
   }

--- a/lib/src/screens/password_input.dart/widgets/password_input_screen.dart
+++ b/lib/src/screens/password_input.dart/widgets/password_input_screen.dart
@@ -1,7 +1,24 @@
 part of '../../../../../viam_flutter_hotspot_provisioning_widget.dart';
 
-class PasswordInputScreen extends StatelessWidget {
+class PasswordInputScreen extends StatefulWidget {
   const PasswordInputScreen({super.key});
+
+  @override
+  State<PasswordInputScreen> createState() => _PasswordInputScreenState();
+}
+
+class _PasswordInputScreenState extends State<PasswordInputScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Clear password when screen is first shown
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        final viewModel = context.read<PasswordInputViewModel>();
+        viewModel.clearPassword();
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8661)  - This PR adds the changes needed in the androidManifest file for the example app in the package to work. It also adds a clearPassword() method to clean up any passwords so that if a user starts typing, then selects a new wifi, the password controller is clear. 

I will release a new version of the package after this is merged