### PR TITLE
[APP-8713] [Hotspot provisioning widget] dark mode in viam mobile app pt1

### DIFF
--- a/example/hotspot_provisioning/lib/main.dart
+++ b/example/hotspot_provisioning/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:viam_example_app/theme.dart';
 import 'start_screen.dart';
 
 void main() {
@@ -12,10 +13,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Hotspot Provisioning',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
-      ),
+      theme: lightTheme,
+      darkTheme: darkTheme,
       home: StartScreen(),
     );
   }

--- a/example/hotspot_provisioning/lib/offline_screen.dart
+++ b/example/hotspot_provisioning/lib/offline_screen.dart
@@ -7,18 +7,15 @@ class OfflineScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
+            Text(
               'Could not connect to the robot. The robot may be offline or the provisioning timed out.',
               textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Colors.black,
-                fontSize: 16,
-              ),
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
             ),
             const SizedBox(height: 24),
             ElevatedButton(

--- a/example/hotspot_provisioning/lib/online_screen.dart
+++ b/example/hotspot_provisioning/lib/online_screen.dart
@@ -7,20 +7,17 @@ class OnlineScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
+            Text(
               'Robot is online. This is from example app.',
               textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Colors.black,
-                fontSize: 16,
-              ),
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
             ),
-            const SizedBox(height: 24),
+            SizedBox(height: 24),
             ElevatedButton(
               onPressed: onPressed,
               child: const Text('Done'),

--- a/example/hotspot_provisioning/lib/provision_new_machine.dart
+++ b/example/hotspot_provisioning/lib/provision_new_machine.dart
@@ -107,10 +107,10 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        backgroundColor: Colors.white,
-        title: const Text('Provision New Machine', style: TextStyle(color: Colors.black)),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        title: Text('Provision New Machine', style: TextStyle(color: Theme.of(context).colorScheme.onSurface)),
       ),
       body: Center(
         child: Column(
@@ -118,10 +118,7 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
           children: [
             if (_robotName != null) Text('Provisioning machine named: $_robotName'),
             if (_robotName != null) const SizedBox(height: 16),
-            if (_isLoading)
-              const CircularProgressIndicator.adaptive(
-                backgroundColor: Colors.black,
-              ),
+            if (_isLoading) const CircularProgressIndicator.adaptive(),
           ],
         ),
       ),

--- a/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
+++ b/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
@@ -132,16 +132,17 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Reconnect Machines'),
+        title: Text('Reconnect Machines', style: TextStyle(color: Theme.of(context).colorScheme.onSurface)),
       ),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator.adaptive(backgroundColor: Colors.black))
+          ? const Center(child: CircularProgressIndicator.adaptive())
           : ListView.builder(
               padding: const EdgeInsets.all(8),
               itemCount: _robots.length,
               itemBuilder: (context, index) => ListTile(
-                title: Text(_robots[index].robot.name),
-                subtitle: Text('location: ${_robots[index].locationName}'),
+                title: Text(_robots[index].robot.name, style: TextStyle(color: Theme.of(context).colorScheme.onSurface)),
+                subtitle:
+                    Text('location: ${_robots[index].locationName}', style: TextStyle(color: Theme.of(context).colorScheme.onSurface)),
                 trailing: _robotStatuses[_robots[index].robot.id]?.statusIcon,
                 onTap: () => _goToHotspotProvisioningFlow(context, _viam!, _robots[index].robot),
               ),

--- a/example/hotspot_provisioning/lib/start_screen.dart
+++ b/example/hotspot_provisioning/lib/start_screen.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:viam_flutter_hotspot_provisioning_widget/viam_flutter_hotspot_provisioning_widget.dart';
 import 'reconnect_machines_screen.dart';
@@ -22,10 +21,10 @@ class StartScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        backgroundColor: Colors.white,
-        title: const Text('Hotspot Provisioning', style: TextStyle(color: Colors.black)),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        title: Text('Hotspot Provisioning', style: TextStyle(color: Theme.of(context).colorScheme.onSurface)),
       ),
       body: Center(
         child: Column(

--- a/example/hotspot_provisioning/lib/theme.dart
+++ b/example/hotspot_provisioning/lib/theme.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+final lightTheme = ThemeData(
+  colorScheme: ThemeData().colorScheme.copyWith(
+        primary: Colors.black,
+        secondary: Colors.grey,
+        secondaryContainer: Color.fromRGBO(231, 229, 228, 1.0),
+        outline: Colors.black12,
+        error: Color.fromRGBO(190, 53, 54, 1),
+        onError: Colors.white,
+        surface: Colors.white,
+      ),
+  cardColor: Colors.white,
+  cardTheme: CardTheme(
+    color: Colors.white,
+    elevation: 0,
+    shape: Border.all(
+      color: Colors.black12,
+    ),
+  ),
+  drawerTheme: DrawerThemeData(
+    backgroundColor: Colors.white,
+    shape: Border.all(
+      color: Colors.black12,
+    ),
+  ),
+  filledButtonTheme: FilledButtonThemeData(style: FilledButton.styleFrom(shape: LinearBorder())),
+  fontFamily: 'Public Sans',
+  scaffoldBackgroundColor: ColorScheme.light().surface,
+  snackBarTheme: SnackBarThemeData(
+    backgroundColor: Color.fromRGBO(0, 239, 131, 1),
+    contentTextStyle: TextStyle(color: Colors.black),
+    closeIconColor: Colors.black,
+    showCloseIcon: true,
+  ),
+  splashFactory: NoSplash.splashFactory,
+  appBarTheme: AppBarTheme(backgroundColor: Colors.black, foregroundColor: Colors.white),
+  textTheme: TextTheme().copyWith(headlineMedium: TextStyle().copyWith(color: Colors.black87)),
+  radioTheme: RadioThemeData().copyWith(fillColor: WidgetStatePropertyAll(Colors.black87)),
+  listTileTheme: ListTileThemeData(
+    iconColor: Colors.black,
+    textColor: Colors.black,
+    tileColor: Colors.white,
+  ),
+  progressIndicatorTheme: ProgressIndicatorThemeData(color: Colors.black),
+);
+
+final darkTheme = ThemeData(
+  useMaterial3: false,
+  primaryColor: ThemeData.dark(useMaterial3: true).primaryColor,
+  colorScheme: ColorScheme.highContrastDark().copyWith(
+    primary: Colors.white,
+    secondary: Colors.grey,
+    surface: Colors.black,
+    outline: Colors.white12,
+    secondaryContainer: Colors.white12,
+    error: Color.fromRGBO(190, 53, 54, 1),
+    onError: Colors.white,
+  ),
+  cardColor: Colors.white12,
+  cardTheme: CardTheme(
+    color: Colors.white12,
+    elevation: 0,
+    shape: Border.all(
+      color: Colors.white12,
+    ),
+  ),
+  fontFamily: 'Public Sans',
+  filledButtonTheme: FilledButtonThemeData(style: FilledButton.styleFrom(shape: LinearBorder())),
+  scaffoldBackgroundColor: Colors.black,
+  snackBarTheme: SnackBarThemeData(
+    backgroundColor: Color.fromRGBO(0, 239, 131, 1),
+    contentTextStyle: TextStyle(color: Colors.black),
+    closeIconColor: Colors.black,
+    showCloseIcon: true,
+  ),
+  splashFactory: NoSplash.splashFactory,
+  appBarTheme: AppBarTheme(backgroundColor: Colors.black, foregroundColor: Colors.white),
+  textTheme: TextTheme().copyWith(headlineMedium: TextStyle().copyWith(color: Colors.white)),
+  radioTheme: RadioThemeData().copyWith(fillColor: WidgetStatePropertyAll(Colors.white)),
+  listTileTheme: ListTileThemeData(
+    iconColor: Colors.white,
+    textColor: Colors.white,
+    tileColor: Colors.white12,
+  ),
+  progressIndicatorTheme: ProgressIndicatorThemeData(color: Colors.white),
+);

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -112,7 +112,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
         title = "Connect to your vessel's Wi-Fi";
         actions = [
           IconButton(
-            icon: const Icon(Icons.refresh, color: Colors.black, size: 24.0),
+            icon: Icon(Icons.refresh, color: Theme.of(context).colorScheme.onSurface, size: 24.0),
             onPressed: () => networkSelectionViewModel.getNetworks(refresh: true),
           )
         ];
@@ -142,16 +142,16 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
         ];
         break;
       case 3:
-        return AppBar(backgroundColor: Colors.white, elevation: 0, automaticallyImplyLeading: false);
+        return AppBar(backgroundColor: Theme.of(context).colorScheme.surface, elevation: 0, automaticallyImplyLeading: false);
     }
 
     return AppBar(
-      title: Text(title, style: const TextStyle(color: Colors.black, fontSize: 18.0, fontWeight: FontWeight.w500)),
-      backgroundColor: Colors.white,
+      title: Text(title, style: TextStyle(color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0, fontWeight: FontWeight.w500)),
+      backgroundColor: Theme.of(context).colorScheme.surface,
       elevation: 0,
       actions: actions,
       leading: IconButton(
-        icon: const Icon(Icons.arrow_back, size: 24, color: Colors.black),
+        icon: Icon(Icons.arrow_back, size: 24, color: Theme.of(context).colorScheme.onSurface),
         onPressed: () {
           FocusScope.of(context).unfocus();
           if (_pageController.page == 0) {
@@ -173,6 +173,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
       ],
       child: Builder(builder: (context) {
         return Scaffold(
+          backgroundColor: Theme.of(context).colorScheme.surface,
           appBar: _buildAppBar(context),
           body: SafeArea(
             child: PageView(

--- a/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
@@ -26,10 +26,10 @@ class ConnectHotspotPrefixScreen extends StatefulWidget {
 
 class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen> {
   late final ConnectHotspotPrefixViewModel _viewModel;
-  static const listStyle = TextStyle(
-    color: Colors.black,
-    fontSize: 16.0,
-  );
+  TextStyle get listStyle => TextStyle(
+        color: Theme.of(context).colorScheme.onSurface,
+        fontSize: 16.0,
+      );
 
   @override
   void initState() {
@@ -68,9 +68,9 @@ class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen>
                       padding: const EdgeInsets.symmetric(horizontal: 14.0, vertical: 24.0),
                       child: Text(
                         "Steps to connect to your device:",
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 20.0,
-                          color: Colors.black,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                       ),
                     ),

--- a/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
+++ b/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
@@ -67,92 +67,95 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                                   },
                                 );
                               },
-                              child: const Text(
+                              child: Text(
                                 "My network isn't showing up",
-                                style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+                                style: TextStyle(color: Theme.of(context).colorScheme.onPrimary, fontWeight: FontWeight.w500),
                               ),
                             ),
                             FilledButton(
                               onPressed: _viewModel!.loadingNetworks ? null : () => _viewModel!.getNetworks(refresh: true),
-                              child: const Row(
+                              child: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
-                                  Icon(Icons.refresh, color: Colors.white),
+                                  Icon(Icons.refresh, color: Theme.of(context).colorScheme.onPrimary),
                                   SizedBox(width: 8),
-                                  Text("Try again", style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500)),
+                                  Text("Try again",
+                                      style: TextStyle(color: Theme.of(context).colorScheme.onPrimary, fontWeight: FontWeight.w500)),
                                 ],
                               ),
                             ),
                           ],
                           titleString: "No networks found",
                           bodyString: "Is your device powered on and nearby? Try turning the device off and back on.")
-                      : Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
-                              child: Text(
-                                "Connect to your machine's Wi-Fi",
-                                style: TextStyle(
-                                  fontSize: 14.0,
-                                  color: Colors.black,
+                      : Stack(children: [
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+                                child: Text(
+                                  "Connect to your machine's Wi-Fi",
+                                  style: TextStyle(
+                                    fontSize: 14.0,
+                                    color: Theme.of(context).colorScheme.onSurface,
+                                  ),
                                 ),
                               ),
-                            ),
-                            Expanded(
-                              child: ListView.builder(
-                                shrinkWrap: true,
-                                itemCount: _viewModel!.machineVisibleNetworks.length,
-                                itemBuilder: (BuildContext context, int index) {
-                                  return GestureDetector(
-                                    onTap: () => widget.onSelectNetwork(_viewModel!.machineVisibleNetworks[index]),
-                                    child: ProvisioningListItem(
-                                      textString: _viewModel!.machineVisibleNetworks[index].ssid,
-                                      leading: Icon(
-                                        _viewModel!.signalToIcon(_viewModel!.machineVisibleNetworks[index].signal),
-                                        size: 24.0,
-                                        color: Colors.grey,
+                              Expanded(
+                                child: ListView.builder(
+                                  shrinkWrap: true,
+                                  itemCount: _viewModel!.machineVisibleNetworks.length,
+                                  itemBuilder: (BuildContext context, int index) {
+                                    return GestureDetector(
+                                      onTap: () => widget.onSelectNetwork(_viewModel!.machineVisibleNetworks[index]),
+                                      child: ProvisioningListItem(
+                                        textString: _viewModel!.machineVisibleNetworks[index].ssid,
+                                        leading: Icon(
+                                          _viewModel!.signalToIcon(_viewModel!.machineVisibleNetworks[index].signal),
+                                          size: 24.0,
+                                          color: Colors.grey,
+                                        ),
+                                        add: false,
+                                        trailing: Icon(
+                                          _viewModel!.securityToIcon(_viewModel!.machineVisibleNetworks[index].security),
+                                          size: 20.0,
+                                          color: Colors.grey,
+                                        ),
                                       ),
-                                      add: false,
-                                      trailing: Icon(
-                                        _viewModel!.securityToIcon(_viewModel!.machineVisibleNetworks[index].security),
-                                        size: 20.0,
-                                        color: Colors.grey,
-                                      ),
-                                    ),
-                                  );
-                                },
-                              ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.symmetric(vertical: 12.0),
-                              child: Center(
-                                child: ElevatedButton(
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: Colors.black,
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(24.0),
-                                    ),
-                                    padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
-                                  ),
-                                  onPressed: () {
-                                    showDialog(
-                                      context: context,
-                                      builder: (BuildContext context) {
-                                        return TroubleshootingDialog(onManualEntry: widget.onManualEntry);
-                                      },
                                     );
                                   },
-                                  child: const Text(
-                                    "My network isn't showing up",
-                                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+                                ),
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(vertical: 12.0),
+                                child: Center(
+                                  child: ElevatedButton(
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: Colors.black,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(24.0),
+                                      ),
+                                      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
+                                    ),
+                                    onPressed: () {
+                                      showDialog(
+                                        context: context,
+                                        builder: (BuildContext context) {
+                                          return TroubleshootingDialog(onManualEntry: widget.onManualEntry);
+                                        },
+                                      );
+                                    },
+                                    child: Text(
+                                      "My network isn't showing up",
+                                      style: TextStyle(color: Theme.of(context).colorScheme.onPrimary, fontWeight: FontWeight.w500),
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ],
-                        ),
+                            ],
+                          ),
+                        ]),
             ),
           ],
         );

--- a/lib/src/screens/network_selection.dart/widgets/provisioning_list_item.dart
+++ b/lib/src/screens/network_selection.dart/widgets/provisioning_list_item.dart
@@ -14,7 +14,7 @@ class ProvisioningListItem extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 16.0),
       child: Container(
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: Theme.of(context).colorScheme.surface,
           border: Border.all(
             width: 1.0,
             color: Colors.grey,
@@ -29,7 +29,7 @@ class ProvisioningListItem extends StatelessWidget {
               textString,
               style: TextStyle(
                 fontSize: 16.0,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             trailing: trailing,

--- a/lib/src/screens/network_selection.dart/widgets/troubleshooting_dialog.dart
+++ b/lib/src/screens/network_selection.dart/widgets/troubleshooting_dialog.dart
@@ -11,7 +11,7 @@ class TroubleshootingDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(24.0),
       ),
@@ -21,21 +21,21 @@ class TroubleshootingDialog extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
+            Text(
               "Troubleshooting",
               style: TextStyle(
                 fontSize: 22,
                 fontWeight: FontWeight.w400,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 16),
-            const Text(
+            Text(
               "If your boat's Wi-Fi network isn't showing up in this list, turn your Specter AI device off and back on again.\n\n"
               "If you've tried this and it still isn't appearing, you can connect by manually entering your network info.",
               style: TextStyle(
                 fontSize: 15,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 24),

--- a/lib/src/screens/password_input.dart/widgets/password_input_screen.dart
+++ b/lib/src/screens/password_input.dart/widgets/password_input_screen.dart
@@ -36,19 +36,19 @@ class _PasswordInputScreenState extends State<PasswordInputScreen> {
               padding: const EdgeInsets.fromLTRB(16.0, 18.0, 0.0, 8.0),
               child: Row(
                 children: [
-                  const Text(
+                  Text(
                     "Wi-Fi network: ",
                     style: TextStyle(
                       fontSize: 14.0,
-                      color: Colors.black,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                   Text(
                     viewModel.network!.ssid,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 15.0,
                       fontWeight: FontWeight.bold,
-                      color: Colors.black,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                 ],
@@ -57,14 +57,14 @@ class _PasswordInputScreenState extends State<PasswordInputScreen> {
           else
             _manuallyEnterSSIDInput(context),
           if (!isPublicNetwork) ...[
-            const Padding(
+            Padding(
               padding: EdgeInsets.fromLTRB(16.0, 16.0, 0.0, 12.0),
               child: Text(
                 "Password",
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 16.0,
-                  color: Colors.black,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
               ),
             ),
@@ -80,7 +80,8 @@ class _PasswordInputScreenState extends State<PasswordInputScreen> {
                   focusedBorder: const OutlineInputBorder(borderSide: BorderSide(color: Colors.grey, width: 3.0)),
                   border: const OutlineInputBorder(borderSide: BorderSide(color: Colors.grey, width: 3.0)),
                   suffixIcon: IconButton(
-                    icon: Icon(viewModel.obscureText ? Icons.visibility_off : Icons.visibility, color: Colors.black),
+                    icon: Icon(viewModel.obscureText ? Icons.visibility_off : Icons.visibility,
+                        color: Theme.of(context).colorScheme.onSurface),
                     onPressed: () => viewModel.toggleObscureText(),
                   ),
                 ),
@@ -102,14 +103,14 @@ class _PasswordInputScreenState extends State<PasswordInputScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Padding(
+        Padding(
           padding: EdgeInsets.fromLTRB(16.0, 16.0, 0.0, 12.0),
           child: Text(
             "Wi-Fi network name",
             style: TextStyle(
               fontWeight: FontWeight.bold,
               fontSize: 16.0,
-              color: Colors.black,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
           ),
         ),
@@ -118,8 +119,8 @@ class _PasswordInputScreenState extends State<PasswordInputScreen> {
           child: TextField(
             controller: viewModel.ssidController,
             autocorrect: false,
-            decoration: const InputDecoration(
-              labelStyle: TextStyle(fontSize: 14.0, color: Colors.black),
+            decoration: InputDecoration(
+              labelStyle: TextStyle(fontSize: 14.0, color: Theme.of(context).colorScheme.onSurface),
               floatingLabelBehavior: FloatingLabelBehavior.never,
               enabledBorder: OutlineInputBorder(borderSide: BorderSide(color: Colors.grey, width: 3.0)),
               focusedBorder: OutlineInputBorder(borderSide: BorderSide(color: Colors.grey, width: 3.0)),

--- a/lib/src/screens/shared_widgets/no_content_widget.dart
+++ b/lib/src/screens/shared_widgets/no_content_widget.dart
@@ -30,7 +30,7 @@ class NoContentWidget extends StatelessWidget {
             titleString,
             style: TextStyle(
               fontSize: 16.0,
-              color: Colors.black,
+              color: Theme.of(context).colorScheme.onSurface,
               fontWeight: FontWeight.bold,
             ),
           ),
@@ -42,7 +42,7 @@ class NoContentWidget extends StatelessWidget {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 14.0,
-                  color: Colors.black,
+                  color: Theme.of(context).colorScheme.onSurface,
                   fontWeight: FontWeight.w400,
                 ),
               ),

--- a/lib/src/screens/shared_widgets/primary_button.dart
+++ b/lib/src/screens/shared_widgets/primary_button.dart
@@ -16,18 +16,21 @@ class PrimaryButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return FilledButton(
       onPressed: (isLoading || onPressed == null) ? null : onPressed,
-      style: OutlinedButton.styleFrom(backgroundColor: Colors.black),
+      style: OutlinedButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
       child: isLoading
-          ? const SizedBox(
+          ? SizedBox(
               width: 20,
               height: 20,
               child: CircularProgressIndicator.adaptive(
-                backgroundColor: Colors.white,
+                backgroundColor: Theme.of(context).colorScheme.onPrimary,
               ),
             )
           : Text(
               text,
-              style: TextStyle(fontWeight: FontWeight.w500, color: onPressed != null ? Colors.white : Color(0x80F7F7F8)),
+              style: TextStyle(
+                fontWeight: FontWeight.w500,
+                color: onPressed != null ? Theme.of(context).colorScheme.onPrimary : Colors.grey.shade500,
+              ),
             ),
     );
   }


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8713) - The widget was not inheriting the theme colors because I was hardcoding the colors before. Now I have removed all places where I hardcoded the colors and used the themes instead. I tested in both light mode and dark mode. I added themes.dart to the example app which is the same themes file we have in the viam mobile app. Next I will test to make sure the updated widgets works in the viam mobile app, but because my theme.dart is the same I am hopeful that it will. 