### PR TITLE
[APP-8745] wrong hotspot password for hotspot provisioning widget

### DIFF
--- a/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
@@ -135,7 +135,7 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
             _pollingTimer?.cancel();
             _setFoundValidSmartMachineStatus(true);
             _setPollingForMachine(false);
-            // TODO: continue with a found machine for machine already exists flow
+            // TODO (APP-8749): Continue with a found machine for machine already exists flow
             _onNavigateToNetworkSelection();
           } catch (e) {
             debugPrint('Error during smart machine status check, continuing polling. Error: $e');

--- a/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
@@ -160,7 +160,7 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
         _findProvisionedMachine();
         return;
       }
-      // If we are not connected to the hotspot, we need to connect to it. 
+      // If we are not connected to the hotspot, we need to connect to it.
       final disconnected = await PluginWifiConnect.disconnect();
       debugPrint('disconnected: $disconnected');
       debugPrint('Connecting to $_hotspotPrefix-#### hotspot');
@@ -171,7 +171,7 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
         isWpa3: false,
         saveNetwork: true, // flips joinOnce on iOS to false
       );
-      // Now that we have attempted to connect to the hotspot, we need to check if we were successful. 
+      // Now that we have attempted to connect to the hotspot, we need to check if we were successful.
       switch (connected) {
         case true:
           debugPrint('Connected to hotspot');
@@ -184,27 +184,29 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
           }
           break;
         case false:
-          // If we land here, either the password is wrong or the isWep parameter is wrong. 
-          _setWrongPassword(true);
-          throw Exception(
-              'Finished connection attempt with connected=false and no error');
+          // If we land here, either the password is wrong or the isWep parameter is wrong or we are just having network issues.
+          // Since we are not positive what the problem is, we will try a few more times until suggesting the user to check the password.
+          throw Exception('Finished connection attempt with connected=false and no error');
         case null:
           _setIsAttemptingConnectionToHotspot(false);
           break; // user cancelled, do nothing
       }
     } catch (e) {
-      // We will retry connectToHotspot 2 times automatically for the user as a buffer.  
+      // We will retry connectToHotspot 2 times automatically for the user as a buffer.
       if (_retryCount < 2 && !_wrongPassword) {
         _setRetryCount(_retryCount + 1);
         await Future.delayed(const Duration(seconds: 2));
         connectToHotspot();
       } else {
-        // After 2 retries, we will let the user retry if they want. 
-        debugPrint('Error connecting to hotspot: ${e.toString()}');
+        // After 2 retries, we assume it might be a wrong password
+        debugPrint('Error connecting to hotspot after ${_retryCount + 1} attempts: ${e.toString()}');
+        if (e.toString().contains('Finished connection attempt with connected=false and no error')) {
+          _setWrongPassword(true);
+        }
         _setIsRetryingHotspot(true);
         _setRetryCount(0);
         _setIsAttemptingConnectionToHotspot(false);
-        _setConnectedToHotspot(false);  
+        _setConnectedToHotspot(false);
       }
     }
   }

--- a/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
@@ -148,13 +148,14 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
   void connectToHotspot() async {
     try {
       debugPrint('connectToHotspot called and retryCount is $_retryCount');
+      _setWrongPassword(false);
       _setIsAttemptingConnectionToHotspot(true);
       _setIsRetryingHotspot(false);
 
       final connectedSSID = await PluginWifiConnect.ssid;
       debugPrint('Current SSID: $connectedSSID');
       // In case we are already connected to the hotspot, we can just go to the next step, finding the provisioned machine.
-      if (connectedSSID != null && connectedSSID.startsWith(_hotspotPrefix)) {
+      if (connectedSSID != null && connectedSSID.startsWith(_hotspotPrefix) && _connectedToHotspot) {
         debugPrint('Already connected to $_hotspotPrefix hotspot');
         _findProvisionedMachine();
         return;

--- a/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/view_model/connect_hotspot_prefix_view_model.dart
@@ -26,6 +26,7 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
   bool _pollingForMachine = false;
   bool _connectedToHotspot = false;
   int _retryCount = 0;
+  bool _wrongPassword = false;
 
   bool get isAttemptingConnectionToHotspot => _isAttemptingConnectionToHotspot;
   bool get isRetryingHotspot => _isRetryingHotspot;
@@ -33,6 +34,7 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
   bool get pollingForMachine => _pollingForMachine;
   bool get connectedToHotspot => _connectedToHotspot;
   int get retryCount => _retryCount;
+  bool get wrongPassword => _wrongPassword;
 
   void _setIsAttemptingConnectionToHotspot(bool value) {
     _isAttemptingConnectionToHotspot = value;
@@ -61,6 +63,11 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
 
   void _setRetryCount(int value) {
     _retryCount = value;
+    notifyListeners();
+  }
+
+  void _setWrongPassword(bool value) {
+    _wrongPassword = value;
     notifyListeners();
   }
 
@@ -107,11 +114,11 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
     return await _viam.provisioningClient.getSmartMachineStatus();
   }
 
+// This function should only ever be called after we are connected to the hotspot
   void _findProvisionedMachine() {
     if (_pollingForMachine || _foundValidSmartMachineStatus) return;
 
     _setPollingForMachine(true);
-    _setConnectedToHotspot(true);
     _setIsAttemptingConnectionToHotspot(false);
     _setRetryCount(0);
 
@@ -146,12 +153,13 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
 
       final connectedSSID = await PluginWifiConnect.ssid;
       debugPrint('Current SSID: $connectedSSID');
+      // In case we are already connected to the hotspot, we can just go to the next step, finding the provisioned machine.
       if (connectedSSID != null && connectedSSID.startsWith(_hotspotPrefix)) {
         debugPrint('Already connected to $_hotspotPrefix hotspot');
         _findProvisionedMachine();
         return;
       }
-
+      // If we are not connected to the hotspot, we need to connect to it. 
       final disconnected = await PluginWifiConnect.disconnect();
       debugPrint('disconnected: $disconnected');
       debugPrint('Connecting to $_hotspotPrefix-#### hotspot');
@@ -162,33 +170,40 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
         isWpa3: false,
         saveNetwork: true, // flips joinOnce on iOS to false
       );
-
+      // Now that we have attempted to connect to the hotspot, we need to check if we were successful. 
       switch (connected) {
         case true:
           debugPrint('Connected to hotspot');
           final connectedSSID = await PluginWifiConnect.ssid;
           if (connectedSSID != null && connectedSSID != '<unknown ssid>') {
+            _setConnectedToHotspot(true);
             _findProvisionedMachine();
           } else {
             throw Exception('Connected to hotspot but no or unknown SSID returned');
           }
           break;
         case false:
-          throw Exception('Finished connection attempt with connected=false and no error');
+          // If we land here, either the password is wrong or the isWep parameter is wrong. 
+          _setWrongPassword(true);
+          throw Exception(
+              'Finished connection attempt with connected=false and no error');
         case null:
           _setIsAttemptingConnectionToHotspot(false);
           break; // user cancelled, do nothing
       }
     } catch (e) {
-      if (_retryCount < 2) {
+      // We will retry connectToHotspot 2 times automatically for the user as a buffer.  
+      if (_retryCount < 2 && !_wrongPassword) {
         _setRetryCount(_retryCount + 1);
         await Future.delayed(const Duration(seconds: 2));
         connectToHotspot();
       } else {
+        // After 2 retries, we will let the user retry if they want. 
         debugPrint('Error connecting to hotspot: ${e.toString()}');
         _setIsRetryingHotspot(true);
         _setRetryCount(0);
         _setIsAttemptingConnectionToHotspot(false);
+        _setConnectedToHotspot(false);  
       }
     }
   }

--- a/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
@@ -102,6 +102,26 @@ class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen>
                           ],
                         ),
                       ),
+                    if (_viewModel.wrongPassword)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 14.0, bottom: 20.0),
+                        child: Column(
+                          children: [
+                            Row(
+                              children: [
+                                Icon(Icons.error, color: Colors.red),
+                                const SizedBox(width: 8.0),
+                                Expanded(
+                                  child: Text(
+                                    "Incorrect password was given for the device's hotspot. Please check the password and try again.",
+                                    style: listStyle.copyWith(fontSize: 15.0),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
                   ],
                 ),
               ),

--- a/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
+++ b/lib/src/screens/connect_hotspot_prefix.dart/widgets/connect_hotspot_prefix_screen.dart
@@ -113,7 +113,7 @@ class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen>
                                 const SizedBox(width: 8.0),
                                 Expanded(
                                   child: Text(
-                                    "Incorrect password was given for the device's hotspot. Please check the password and try again.",
+                                    "Having trouble connecting? The password may be incorrect. Please check it or try again.",
                                     style: listStyle.copyWith(fontSize: 15.0),
                                   ),
                                 ),

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -95,6 +95,7 @@ class PasswordInputViewModel extends ChangeNotifier {
       if (!response.hasSmartMachineCredentials) {
         await _setSmartMachineCredentials();
       }
+      // TODO: if we have smart machine credenitals, should we tell them>
       // For public networks, submit empty string as password
       final String password = _network != null && isPublicNetwork(_network!) ? '' : _passwordController.text.trim();
       await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -95,7 +95,6 @@ class PasswordInputViewModel extends ChangeNotifier {
       if (!response.hasSmartMachineCredentials) {
         await _setSmartMachineCredentials();
       }
-      // TODO: if we have smart machine credenitals, should we tell them>
       // For public networks, submit empty string as password
       final String password = _network != null && isPublicNetwork(_network!) ? '' : _passwordController.text.trim();
       await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8745) This PR does two things:
1.  Moves where are are setting setConnectedToHotspot(true). we should be calling this when we actually suceed at connecting, not at a random spot in `findProvisionedMachine`,
2.  Creates a new function called `_setWrongPassword` which we call when this call -->` final connected = await PluginWifiConnect.connectToSecureNetworkByPrefix(...)` fails. This call fails for two reasons , either password doesn't match or the isWep parameter isn't set correctly.

incorrect password flow:

https://github.com/user-attachments/assets/61db6689-a721-4aea-80d6-e0d9b7a837de


correct password flow:

https://github.com/user-attachments/assets/822cc7a0-dff7-44cd-acf6-37d050beac09


