### PR TITLE
change to published package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,7 @@ environment:
 dependencies:
    flutter:
     sdk: flutter
-   plugin_wifi_connect:
-    git: 
-      url: https://github.com/viamrobotics/plugin_wifi_connect
-      ref: 0.0.2
+   plugin_wifi_connect: 2.0.1
    viam_sdk: 0.6.6
    permission_handler: ^12.0.0+1
    flutter_platform_widgets: ^8.0.0


### PR DESCRIPTION
Update to use the latest version of plugin_wifi_connect and not the forked version of the repo that kevin made. This is because in order to publish a package on pub.dev we need to not have any dependencies linked to unpublished packages/ github repos. 