### PR TITLE
Lower platform widget minimum

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
    plugin_wifi_connect: 2.0.1
    viam_sdk: 0.6.6
    permission_handler: ^12.0.0+1
-   flutter_platform_widgets: ^8.0.0
+   flutter_platform_widgets: ^7.0.1
    provider: ^6.1.5
  
   


### PR DESCRIPTION
```
Because every version of viam_flutter_hotspot_provisioning_widget depends on flutter_platform_widgets ^8.0.0 and name depends on
  flutter_platform_widgets ^7.0.1, viam_flutter_hotspot_provisioning_widget is forbidden.
So, because name depends on viam_flutter_hotspot_provisioning_widget any, version solving failed.
Failed to update packages.
```

Lowering the minimum here. Trying to add to a an app and this is blocking that. We can afford to be less prescriptive here we're not relying on something specific in version 8>