### PR TITLE
Hotspot package: update to read fragmentId from agent + update part with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ final result = await HotspotProvisioningFlow.show(
   robot: robot,
   viam: viam,
   mainPart: mainPart,
+  fragmentId: 'your-fragment-id', // Optional, if null, the fragmentId will be read from the device.
   hotspotPrefix: 'your-hotspot-prefix',  // Must match viam-defaults.json & must be at least 3 characters long 
   hotspotPassword: 'your-hotspot-password', // Must match viam-defaults.json
 );
@@ -136,6 +137,7 @@ The main widget that handles the entire provisioning flow.
 What you need to pass into the widget:
 - `robot`: The Viam robot to provision
 - `viam`: The Viam SDK instance
+- `fragmentId`: The optional fragment ID you want to configure this robot with.
 - `mainPart`: The main robot part
 - `hotspotPrefix`: The SSID prefix for the robot's hotspot. This prefix **must match** the prefix you set in the viam-defaults.json. **The hotspot prefix must be at least 3 characters long.**
 - `hotspotPassword`: The password for the robot's hotspot. This password **must match** the password you set in the viam-defaults.json.

--- a/example/hotspot_provisioning/lib/consts.dart
+++ b/example/hotspot_provisioning/lib/consts.dart
@@ -1,9 +1,9 @@
 class Consts {
-  static const String hotspotPrefix = '';
-  static const String hotspotPassword = '';
+  static const String hotspotPrefix = 'viam';
+  static const String hotspotPassword = 'ViamMob1le';
 
-  static const String apiKeyId = '';
-  static const String apiKey = '';
+  static const String apiKeyId = '3648a77b-b85f-4fcb-ba1e-31f66e2d79ee';
+  static const String apiKey = 'jwp05ew6ayc53wyhmttnt2u2y21x4lr0';
 
-  static const String organizationId = '';
+  static const String organizationId = '782a4050-a135-4e19-ad5e-d98b33ed7309';
 }

--- a/example/hotspot_provisioning/lib/consts.dart
+++ b/example/hotspot_provisioning/lib/consts.dart
@@ -1,9 +1,9 @@
 class Consts {
-  static const String hotspotPrefix = 'viam';
-  static const String hotspotPassword = 'ViamMob1le';
+  static const String hotspotPrefix = '';
+  static const String hotspotPassword = '';
 
-  static const String apiKeyId = '3648a77b-b85f-4fcb-ba1e-31f66e2d79ee';
-  static const String apiKey = 'jwp05ew6ayc53wyhmttnt2u2y21x4lr0';
+  static const String apiKeyId = '';
+  static const String apiKey = '';
 
-  static const String organizationId = '782a4050-a135-4e19-ad5e-d98b33ed7309';
+  static const String organizationId = '';
 }

--- a/example/hotspot_provisioning/lib/provision_new_machine.dart
+++ b/example/hotspot_provisioning/lib/provision_new_machine.dart
@@ -78,7 +78,7 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
           robot: robot,
           viam: viam,
           mainPart: mainPart,
-          fragmentId: 'test-fragment-id',
+          fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
           hotspotPrefix: Consts.hotspotPrefix, // This must be at least 3 characters long
           hotspotPassword: Consts.hotspotPassword,
         );

--- a/example/hotspot_provisioning/lib/provision_new_machine.dart
+++ b/example/hotspot_provisioning/lib/provision_new_machine.dart
@@ -78,6 +78,7 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
           robot: robot,
           viam: viam,
           mainPart: mainPart,
+          fragmentId: 'test-fragment-id',
           hotspotPrefix: Consts.hotspotPrefix, // This must be at least 3 characters long
           hotspotPassword: Consts.hotspotPassword,
         );

--- a/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
+++ b/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
@@ -107,7 +107,7 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
         robot: existingRobot,
         viam: viam,
         mainPart: mainPart,
-        fragmentId: 'test-fragment-id',
+        fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
       );

--- a/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
+++ b/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
@@ -107,6 +107,7 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
         robot: existingRobot,
         viam: viam,
         mainPart: mainPart,
+        fragmentId: 'test-fragment-id',
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
       );

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -6,7 +6,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
   final RobotPart mainPart;
   final String hotspotPrefix;
   final String hotspotPassword;
-  final String? fragmentId; // I need to make this optional?? but why are we saying it can be null?? 
+  final String? fragmentId;
 
   const HotspotProvisioningFlow({
     super.key,
@@ -26,7 +26,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
     required RobotPart mainPart,
     required String hotspotPrefix,
     required String hotspotPassword,
-    String? fragmentId, // this is optional??? 
+    String? fragmentId,
   }) {
     return Navigator.of(context).push<HotspotProvisioningResult?>(
       MaterialPageRoute(
@@ -61,9 +61,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     _passwordInputViewModel = PasswordInputViewModel(
       viam: widget.viam,
       mainPart: widget.mainPart,
-      fragmentId: widget.fragmentId, // so if the user does not pass in a fragmentId b/c we just made it optional above, what will be passed here?? the default value for fragmentId is null because its optional and not requred, so if a user does not pass in a fragmentId this will be null. 
-      robot: widget.robot,
-      // onPasswordSubmitted: () => _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut),
+      fragmentId: widget.fragmentId,
       onPasswordSubmitted: (fragmentId) {
         setState(() {
           _determinedFragmentId = fragmentId;

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -6,6 +6,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
   final RobotPart mainPart;
   final String hotspotPrefix;
   final String hotspotPassword;
+  final String? fragmentId; // I need to make this optional?? but why are we saying it can be null?? 
 
   const HotspotProvisioningFlow({
     super.key,
@@ -14,6 +15,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
     required this.mainPart,
     required this.hotspotPrefix,
     required this.hotspotPassword,
+    this.fragmentId,
   });
 
 // Static method to push this flow and get a result
@@ -24,6 +26,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
     required RobotPart mainPart,
     required String hotspotPrefix,
     required String hotspotPassword,
+    String? fragmentId, // this is optional??? 
   }) {
     return Navigator.of(context).push<HotspotProvisioningResult?>(
       MaterialPageRoute(
@@ -33,6 +36,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
           mainPart: mainPart,
           hotspotPrefix: hotspotPrefix,
           hotspotPassword: hotspotPassword,
+          fragmentId: fragmentId,
         ),
       ),
     );
@@ -47,6 +51,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
   late final NetworkSelectionViewModel _networkSelectionViewModel;
   late final PasswordInputViewModel _passwordInputViewModel;
   int _currentPage = 0;
+  String? _determinedFragmentId;
 
   @override
   void initState() {
@@ -56,7 +61,15 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     _passwordInputViewModel = PasswordInputViewModel(
       viam: widget.viam,
       mainPart: widget.mainPart,
-      onPasswordSubmitted: () => _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut),
+      fragmentId: widget.fragmentId, // so if the user does not pass in a fragmentId b/c we just made it optional above, what will be passed here?? the default value for fragmentId is null because its optional and not requred, so if a user does not pass in a fragmentId this will be null. 
+      robot: widget.robot,
+      // onPasswordSubmitted: () => _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut),
+      onPasswordSubmitted: (fragmentId) {
+        setState(() {
+          _determinedFragmentId = fragmentId;
+        });
+        _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+      },
       showErrorDialog: (context, {required title, String? error}) => showAdaptiveDialog(
         context: context,
         builder: (context) => AlertDialog.adaptive(
@@ -206,6 +219,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
                   viam: widget.viam,
                   mainPart: widget.mainPart,
                   onStatusDetermined: onConfirmationStatusDetermined,
+                  fragmentId: _determinedFragmentId,
                 )
               ],
             ),

--- a/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
+++ b/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
@@ -56,7 +56,7 @@ class ConfirmationViewModel extends ChangeNotifier {
     if (_robotStatus == RobotStatus.online) {
       _onStatusDetermined.call(_robot, RobotStatus.online);
       _timer?.cancel();
-      _fragmentOverride(_viam, _fragmentId, _mainPart, _robot); 
+      _fragmentOverride(_viam, _fragmentId, _mainPart, _robot);
       // robot provisioning did not complete successfully and is offline
     } else if (_robotStatus == RobotStatus.offline) {
       _onStatusDetermined.call(_robot, RobotStatus.offline);

--- a/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
+++ b/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
@@ -5,8 +5,12 @@ class ConfirmationViewModel extends ChangeNotifier {
     required Viam viam,
     required Robot robot,
     required void Function(Robot robot, RobotStatus status) onStatusDetermined,
+    required String? fragmentId,
+    required RobotPart mainPart,
   })  : _viam = viam,
         _robot = robot,
+        _fragmentId = fragmentId,
+        _mainPart = mainPart,
         _onStatusDetermined = onStatusDetermined {
     _disconnectFromHotspot();
     _startCheckingOnline();
@@ -14,6 +18,8 @@ class ConfirmationViewModel extends ChangeNotifier {
 
   final Viam _viam;
   final Robot _robot;
+  final String? _fragmentId;
+  final RobotPart _mainPart;
   final void Function(Robot robot, RobotStatus status) _onStatusDetermined;
 
   Timer? _timer;
@@ -50,6 +56,8 @@ class ConfirmationViewModel extends ChangeNotifier {
       _onStatusDetermined.call(_robot, RobotStatus.online);
       _timer?.cancel();
       // robot provisioning did not complete successfully and is offline
+      _fragmentOverride(_viam, _fragmentId, _mainPart, _robot); // we should call the fragment ovreride when the robot is online?
+
     } else if (_robotStatus == RobotStatus.offline) {
       _onStatusDetermined.call(_robot, RobotStatus.offline);
       _timer?.cancel();
@@ -78,6 +86,23 @@ class ConfirmationViewModel extends ChangeNotifier {
     debugPrint('disconnected from hotspot: $disconnected');
     // TODO (APP-8749): Associate a unique ID from machine with (maybe hotspot ssid) w/ robot as part of the machine already exists flow.
     // This is so we can associate the machine with the correct robot when we reconnect.
+  }
+
+  Future<void> _fragmentOverride(Viam viam, String? fragmentId, RobotPart robotPart, Robot robot) async {
+    if (fragmentId == null || fragmentId.isEmpty) return;
+    // if (fragmentIdToWrite.isNotEmpty) {
+    //   await _fragmentOverride(_viam, fragmentIdToWrite, _mainPart, _robot); // need to pass robot??
+
+    //   // u are not connected to the internet here so we cannot call fragement override.
+    //   // instead we need to save fragmentId somewhere and we can call it later after we are connected.
+    //   // after we are connected to the network, then call fragmentOverride.
+    //   //make this api call when i am checking the robot status after being connected to the network.
+    // }
+
+    Map<String, dynamic> config = {
+      "fragments": [fragmentId]
+    };
+    await viam.appClient.updateRobotPart(robotPart.id, robot.name, config);
   }
 
   void _getRobotStatus() async {

--- a/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
+++ b/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
@@ -50,14 +50,14 @@ class ConfirmationViewModel extends ChangeNotifier {
   }
 
 // triggers a callback to the hotspot provisioning flow to to indicate if the robot is online or offline
+// Also, at this point we know we are online so we can call the fragment override.
   void _whenFinalRobotStatusIsDetermined() {
     // robot provisioned succesfully and is online
     if (_robotStatus == RobotStatus.online) {
       _onStatusDetermined.call(_robot, RobotStatus.online);
       _timer?.cancel();
+      _fragmentOverride(_viam, _fragmentId, _mainPart, _robot); 
       // robot provisioning did not complete successfully and is offline
-      _fragmentOverride(_viam, _fragmentId, _mainPart, _robot); // we should call the fragment ovreride when the robot is online?
-
     } else if (_robotStatus == RobotStatus.offline) {
       _onStatusDetermined.call(_robot, RobotStatus.offline);
       _timer?.cancel();
@@ -90,15 +90,6 @@ class ConfirmationViewModel extends ChangeNotifier {
 
   Future<void> _fragmentOverride(Viam viam, String? fragmentId, RobotPart robotPart, Robot robot) async {
     if (fragmentId == null || fragmentId.isEmpty) return;
-    // if (fragmentIdToWrite.isNotEmpty) {
-    //   await _fragmentOverride(_viam, fragmentIdToWrite, _mainPart, _robot); // need to pass robot??
-
-    //   // u are not connected to the internet here so we cannot call fragement override.
-    //   // instead we need to save fragmentId somewhere and we can call it later after we are connected.
-    //   // after we are connected to the network, then call fragmentOverride.
-    //   //make this api call when i am checking the robot status after being connected to the network.
-    // }
-
     Map<String, dynamic> config = {
       "fragments": [fragmentId]
     };

--- a/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
+++ b/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
@@ -3,11 +3,12 @@ part of '../../../../../viam_flutter_hotspot_provisioning_widget.dart';
 enum RobotStatus { online, offline, loading }
 
 class ConfirmationScreen extends StatefulWidget {
-  const ConfirmationScreen({super.key, required this.robot, required this.viam, required this.mainPart, required this.onStatusDetermined});
+  const ConfirmationScreen({super.key, required this.robot, required this.viam, required this.mainPart, required this.onStatusDetermined, this.fragmentId});
 
   final Viam viam;
   final Robot robot;
   final RobotPart mainPart;
+  final String? fragmentId;
   final void Function(Robot robot, RobotStatus status) onStatusDetermined;
 
   @override
@@ -24,6 +25,8 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
       viam: widget.viam,
       robot: widget.robot,
       onStatusDetermined: widget.onStatusDetermined,
+      fragmentId: widget.fragmentId,
+      mainPart: widget.mainPart,
     );
   }
 

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -5,14 +5,11 @@ class PasswordInputViewModel extends ChangeNotifier {
     required Viam viam,
     required RobotPart mainPart,
     required String? fragmentId,
-    required Robot robot,
-    // required VoidCallback onPasswordSubmitted,
     required Function(String? fragmentId) onPasswordSubmitted,
     required Function(BuildContext, {required String title, String? error}) showErrorDialog,
   })  : _viam = viam,
         _mainPart = mainPart,
         _fragmentId = fragmentId,
-        _robot = robot,
         _onPasswordSubmitted = onPasswordSubmitted,
         _showErrorDialog = showErrorDialog {
     _passwordController.addListener(_notifyListeners);
@@ -22,8 +19,6 @@ class PasswordInputViewModel extends ChangeNotifier {
   final Viam _viam;
   final RobotPart _mainPart;
   final String? _fragmentId;
-  final Robot _robot;
-  // final VoidCallback _onPasswordSubmitted;
   final Function(String? fragmentId) _onPasswordSubmitted;
   final Function(BuildContext, {required String title, String? error}) _showErrorDialog;
 
@@ -106,19 +101,8 @@ class PasswordInputViewModel extends ChangeNotifier {
       // For public networks, submit empty string as password
       final String password = _network != null && isPublicNetwork(_network!) ? '' : _passwordController.text.trim();
       await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);
-      // do something with the fragmentId here??? response.provisioningInfo.fragmentId
-      // doing some sort of fragment override or something?? 
-      // if fragment id is passed in, use that, otherwise read the fragmentId from the device. 
-      // TODO: check what happens when fragmentId is null. 
-      final fragmentIdToWrite = _fragmentId ?? response.provisioningInfo.fragmentId; // if fragmentId is null, then we will read the fragmentId fro mthe device... but how will the device know what to write ?? confused. 
-      // if (fragmentIdToWrite.isNotEmpty) {
-      //   await _fragmentOverride(_viam, fragmentIdToWrite, _mainPart, _robot); // need to pass robot??
-
-      //   // u are not connected to the internet here so we cannot call fragement override.
-      //   // instead we need to save fragmentId somewhere and we can call it later after we are connected. 
-      //   // after we are connected to the network, then call fragmentOverride. 
-      //   //make this api call when i am checking the robot status after being connected to the network. 
-      // }
+      // Get the fragmentId that was passed in to this hotspot provisioning flow or get it from agent.
+      final fragmentIdToWrite = _fragmentId ?? response.provisioningInfo.fragmentId;  
       await _viam.provisioningClient.exitProvisioning();
       _onPasswordSubmitted(fragmentIdToWrite);
     } catch (e) {

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -4,10 +4,15 @@ class PasswordInputViewModel extends ChangeNotifier {
   PasswordInputViewModel({
     required Viam viam,
     required RobotPart mainPart,
-    required VoidCallback onPasswordSubmitted,
+    required String? fragmentId,
+    required Robot robot,
+    // required VoidCallback onPasswordSubmitted,
+    required Function(String? fragmentId) onPasswordSubmitted,
     required Function(BuildContext, {required String title, String? error}) showErrorDialog,
   })  : _viam = viam,
         _mainPart = mainPart,
+        _fragmentId = fragmentId,
+        _robot = robot,
         _onPasswordSubmitted = onPasswordSubmitted,
         _showErrorDialog = showErrorDialog {
     _passwordController.addListener(_notifyListeners);
@@ -16,7 +21,10 @@ class PasswordInputViewModel extends ChangeNotifier {
 
   final Viam _viam;
   final RobotPart _mainPart;
-  final VoidCallback _onPasswordSubmitted;
+  final String? _fragmentId;
+  final Robot _robot;
+  // final VoidCallback _onPasswordSubmitted;
+  final Function(String? fragmentId) _onPasswordSubmitted;
   final Function(BuildContext, {required String title, String? error}) _showErrorDialog;
 
   final TextEditingController _passwordController = TextEditingController();
@@ -98,8 +106,21 @@ class PasswordInputViewModel extends ChangeNotifier {
       // For public networks, submit empty string as password
       final String password = _network != null && isPublicNetwork(_network!) ? '' : _passwordController.text.trim();
       await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);
+      // do something with the fragmentId here??? response.provisioningInfo.fragmentId
+      // doing some sort of fragment override or something?? 
+      // if fragment id is passed in, use that, otherwise read the fragmentId from the device. 
+      // TODO: check what happens when fragmentId is null. 
+      final fragmentIdToWrite = _fragmentId ?? response.provisioningInfo.fragmentId; // if fragmentId is null, then we will read the fragmentId fro mthe device... but how will the device know what to write ?? confused. 
+      // if (fragmentIdToWrite.isNotEmpty) {
+      //   await _fragmentOverride(_viam, fragmentIdToWrite, _mainPart, _robot); // need to pass robot??
+
+      //   // u are not connected to the internet here so we cannot call fragement override.
+      //   // instead we need to save fragmentId somewhere and we can call it later after we are connected. 
+      //   // after we are connected to the network, then call fragmentOverride. 
+      //   //make this api call when i am checking the robot status after being connected to the network. 
+      // }
       await _viam.provisioningClient.exitProvisioning();
-      _onPasswordSubmitted();
+      _onPasswordSubmitted(fragmentIdToWrite);
     } catch (e) {
       if (!context.mounted) return;
       _showErrorDialog(


### PR DESCRIPTION
(https://viam.atlassian.net/browse/CONSULT-1376) - This PR adds the fragment override feature to the hotspot provisioning flow. Now the user can optionally pass in the fragmentId to the provisioning flow. The flow will look to see if a fragmentId has been passed in and will use that to update the robot part. if no fragmentId was passed in, it will try and read the fragmentId from agent. If there is no fragmentId present in either of those scenarios we will not updateRobotPart with anything.  I was able to get the machine online with the expected fragmentId each time.

This PR also updates the README.md to include info on the optional fragmentId parameter.