### PR TITLE
[APP-8967] Hotspot widget: check agent version

### DIFF
--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -100,10 +100,17 @@ class PasswordInputViewModel extends ChangeNotifier {
       }
       // For public networks, submit empty string as password
       final String password = _network != null && isPublicNetwork(_network!) ? '' : _passwordController.text.trim();
-      await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);
       // Get the fragmentId that was passed in to this hotspot provisioning flow or get it from agent.
-      final fragmentIdToWrite = _fragmentId ?? response.provisioningInfo.fragmentId;  
-      await _viam.provisioningClient.exitProvisioning();
+      final fragmentIdToWrite = _fragmentId ?? response.provisioningInfo.fragmentId;
+      // Check if agent version is greater than or equal to 0.20.0
+      // If it is, we can call exitProvisioning after setting network credentials, otherwise just set network credentials and move on.
+      final agentVersion = Version.parse(response.agentVersion);
+      if (agentVersion >= Version(0, 20, 0)) {
+        await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);
+        await _viam.provisioningClient.exitProvisioning();
+      } else {
+        _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);
+      }
       _onPasswordSubmitted(fragmentIdToWrite);
     } catch (e) {
       if (!context.mounted) return;

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -88,6 +88,7 @@ class PasswordInputViewModel extends ChangeNotifier {
   }
 
   Future<void> submitPassword(BuildContext context) async {
+    Version? agentVersion;
     FocusScope.of(context).unfocus();
     _setLoading(true);
 
@@ -104,8 +105,10 @@ class PasswordInputViewModel extends ChangeNotifier {
       final fragmentIdToWrite = _fragmentId ?? response.provisioningInfo.fragmentId;
       // Check if agent version is greater than or equal to 0.20.0
       // If it is, we can call exitProvisioning after setting network credentials, otherwise just set network credentials and move on.
-      final agentVersion = Version.parse(response.agentVersion);
-      if (agentVersion >= Version(0, 20, 0)) {
+      if (response.agentVersion.isNotEmpty) {
+        agentVersion = Version.parse(response.agentVersion);
+      }
+      if (agentVersion != null && agentVersion >= Version(0, 20, 0)) {
         await _setNetworkCredentials(_network?.ssid.trim() ?? _ssidController.text.trim(), password);
         await _viam.provisioningClient.exitProvisioning();
       } else {

--- a/lib/viam_flutter_hotspot_provisioning_widget.dart
+++ b/lib/viam_flutter_hotspot_provisioning_widget.dart
@@ -9,6 +9,7 @@ import 'package:viam_sdk/viam_sdk.dart';
 
 import 'package:permission_handler/permission_handler.dart' as ph;
 
+import 'package:pub_semver/pub_semver.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
    permission_handler: ^12.0.0+1
    flutter_platform_widgets: ^7.0.1
    provider: ^6.1.5
+   pub_semver: ^2.2.0
  
   
 dev_dependencies:


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-8967) - This PR adds a check to make sure that the version of agent we are on is greater than 0.20.0 before calling exitProvisioning. And if we are on a lower agent version we will not call exitProvisioning. Although most machines should be upgraded to most recent version, this ensures backwards compatability. 

tested with stable version of agent: v0.21.2 and old version of agent v0.16.0 (used preinstall to install the the old agent binary). I was able to get online in both cases. The new version called exitProvisioning and the old version did not (as expected).