### PR TITLE
Relax package constraints in pubspec for package users

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 dependencies:
    flutter:
     sdk: flutter
-   plugin_wifi_connect: 2.0.1
-   viam_sdk: 0.6.6
+   plugin_wifi_connect: ^2.0.1
+   viam_sdk: ^0.6.6
    permission_handler: ^12.0.0+1
    flutter_platform_widgets: ^7.0.1
    provider: ^6.1.5


### PR DESCRIPTION
<img width="679" height="256" alt="Screenshot 2025-09-04 at 4 52 37 PM" src="https://github.com/user-attachments/assets/c43f4a7b-3746-469c-a61c-998345f657e4" />

Warned on publish about this, but the warning is fair and we shouldn't be this stringent