### PR TITLE
[APP-9642] Hotspot provisioning widget supports "replace hardware"

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ final result = await HotspotProvisioningFlow.show(
   hotspotPassword: 'your-hotspot-password', // Must match viam-defaults.json
   promptForCredentials: false, // Use hardcoded credentials
   isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
+  robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
 
 // Option 2: Prompt user for credentials
@@ -132,6 +134,8 @@ final result = await HotspotProvisioningFlow.show(
   fragmentId: 'your-fragment-id',
   promptForCredentials: true, // This will show a credential input screen
   isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
+  robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
 
 // 5. Handle the result
@@ -163,6 +167,8 @@ final result = await HotspotProvisioningFlow.show(
   hotspotPassword: 'your-password',
   promptForCredentials: false, // Use hardcoded credentials
   isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
+  robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
 ```
 
@@ -177,6 +183,8 @@ final result = await HotspotProvisioningFlow.show(
   mainPart: mainPart,
   promptForCredentials: true, // This will show a credential input screen
   isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
+  robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
 ```
 
@@ -193,7 +201,9 @@ What you need to pass into the widget:
 - `hotspotPrefix`: The SSID prefix for the robot's hotspot. This prefix **must match** the prefix you set in the viam-defaults.json. **The hotspot prefix must be at least 3 characters long.** (Optional when `promptForCredentials` is true)
 - `hotspotPassword`: The password for the robot's hotspot. This password **must match** the password you set in the viam-defaults.json. (Optional when `promptForCredentials` is true)
 - `promptForCredentials`: Whether to show a credential input screen for the user to enter hotspot prefix and password. When true, `hotspotPrefix` and `hotspotPassword` are optional.
-- `isNewMachine`: Whether this is a new machine being provisioned for the first time. Set to `true` for new machines, `false` for reconnecting existing machines. When `true`, the fragment override will be performed after successful provisioning.  
+- `isNewMachine`: Whether this is a new machine being provisioned for the first time. Set to `true` for new machines, `false` for reconnecting existing machines. When `true`, the fragment override will be performed after successful provisioning.
+- `replaceHardware`: Whether you are replacing hardware and want to apply a saved robot configuration. Set to `true` when replacing hardware, `false` otherwise.
+- `robotConfig`: Optional saved robot configuration to apply when `replaceHardware` is `true`. Pass the configuration from the old robot that you want to apply to the new robot. Can be omitted when `replaceHardware` is `false`.  
 
 ### HotspotProvisioningResult
 Contains the result of the provisioning attempt:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,36 @@ final result = await HotspotProvisioningFlow.show(
 ```
 
 When `promptForCredentials` is `true`, the `hotspotPrefix` and `hotspotPassword` parameters are optional and will be ignored.
+
+## Hardware Replacement
+
+When replacing hardware, you can preserve the robot's configuration by setting `replaceHardware: true` and passing the saved robot configuration to `robotConfig`.
+
+**Important**: To replace hardware, you need to:
+1. Create a new robot instance for the replacement hardware
+2. Save the configuration from the old robot's main part
+3. Apply the saved configuration to the new robot during provisioning
+
+```dart
+// Get the saved robot configuration from the old robot
+final savedRobotConfig = oldRobotPart.robotConfig.toMap();
+
+// Apply the saved configuration to the new robot
+final result = await HotspotProvisioningFlow.show(
+  context,
+  robot: newRobot, // Pass in the new replacement robot
+  viam: viam,
+  mainPart: newMainPart, // Pass in the new replacement mainPart
+  fragmentId: 'your-fragment-id',
+  hotspotPrefix: 'your-hotspot-prefix',
+  hotspotPassword: 'your-hotspot-password',
+  promptForCredentials: false,
+  isNewMachine: false,
+  replaceHardware: true, // Enable hardware replacement mode
+  robotConfig: savedRobotConfig, // Pass the saved configuration
+);
+```
+
 ## HotspotProvisioningFlow Widget
 The main widget that handles the entire provisioning flow.
 

--- a/example/hotspot_provisioning/README.md
+++ b/example/hotspot_provisioning/README.md
@@ -8,11 +8,11 @@ This example project demonstrates how to use the Viam Flutter Hotspot Provisioni
     - These values should match the prefix and password that were set in the viam-defaults.json. 
     - See the [Machine Setup section](../../README.md#machine-setup) for more info on the viam-defaults.json.
 2. Run the example app by running `flutter run`
-3. Choose "Provision New Machine" or "Reconnect Machine"
+3. Choose "Provision New Machine", "Reconnect Machine", or "Replace Hardware"
 4. Follow the on-screen instructions
 
 ## Use Cases
-The app showcases two main use cases:
+The app showcases three main use cases:
 
 ### 1. Provision a new machine
 This flow demonstrates how to connect a **new robot** to the Viam platform for the first time. The process:
@@ -29,10 +29,18 @@ This flow demonstrates how to **reconnect an existing robot** to a new wifi netw
 - Uses the same hotspot provisioning flow but with an existing robot instance
 <img src="../../screenshots/reconnect_demo.gif" width="250" alt="Re-provisioning Flow">
 
+### 3. Replace hardware
+This flow demonstrates how to **replace hardware** while preserving the robot's configuration. The process:
+- Saves the robot configuration from the old hardware
+- Creates a new robot instance for the replacement hardware
+- Applies the saved configuration to the new robot during provisioning
+- Ensures the new hardware has the same settings as the old hardware
+
 ## How It Works
 
-Both flows utilize the same underlying `HotspotProvisioningFlow` widget, which:
+All three flows utilize the same underlying `HotspotProvisioningFlow` widget, which:
 1. Connects to the robot's hotspot network
 2. Configures the robot's network settings  
 3. Establishes a connection to the Viam platform
-4. Returns the connection status
+4. Applies saved robot configuration (when replacing hardware)
+5. Returns the connection status

--- a/example/hotspot_provisioning/lib/provision_new_machine.dart
+++ b/example/hotspot_provisioning/lib/provision_new_machine.dart
@@ -89,6 +89,8 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
             fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
             promptForCredentials: true,
             isNewMachine: true, // Override fragment for new machine provisioning
+            replaceHardware: false,
+            robotConfig: null,
           );
         } else {
           result = await HotspotProvisioningFlow.show(
@@ -101,6 +103,8 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
             hotspotPassword: Consts.hotspotPassword,
             promptForCredentials: false,
             isNewMachine: true, // Override fragment for new machine provisioning
+            replaceHardware: false,
+            robotConfig: null,
           );
         }
         if (result != null) {

--- a/example/hotspot_provisioning/lib/replace_hardware_screen.dart
+++ b/example/hotspot_provisioning/lib/replace_hardware_screen.dart
@@ -100,7 +100,7 @@ class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
     }
   }
 
-//  so bascially the user needs to provide the new replacement robot and the config from the old robot
+  // Provide the new replacement robot and the config from the old robot.
   Future<(Map<String, dynamic>, RobotPart)> getConfig(Robot robot) async {
     _viam = await Viam.withApiKey(Consts.apiKeyId, Consts.apiKey);
     final parts = await _viam!.appClient.listRobotParts(robot.id);
@@ -129,19 +129,29 @@ class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
         robotConfig: savedRobotConfig, // Be sure to pass in the config from the old robot that you want to apply to the new robot
       );
 
-      if (result != null) {
-        if (result.status == RobotStatus.online) {
-          if (mounted) {
-            Navigator.of(context).push(MaterialPageRoute(builder: (context) => OnlineScreen(onPressed: () => Navigator.of(context).pop())));
-          }
-        } else {
-          if (mounted) {
-            Navigator.of(context)
-                .push(MaterialPageRoute(builder: (context) => OfflineScreen(onPressed: () => Navigator.of(context).pop())));
-          }
-        }
-      } else {
+      if (result == null) {
         debugPrint('No result from HotspotProvisioningFlow. The flow may have been cancelled.');
+        return;
+      }
+      switch (result.status) {
+        case RobotStatus.online:
+          if (mounted) {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => OnlineScreen(onPressed: () => Navigator.of(context).pop())),
+            );
+          }
+          break;
+        case RobotStatus.offline:
+          if (mounted) {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => OfflineScreen(onPressed: () => Navigator.of(context).pop())),
+            );
+          }
+          break;
+        case RobotStatus.loading:
+          // we will never get here as the flow will timeout and the robot will be offline
+          debugPrint('Robot status still loading.');
+          break;
       }
     }
   }

--- a/example/hotspot_provisioning/lib/replace_hardware_screen.dart
+++ b/example/hotspot_provisioning/lib/replace_hardware_screen.dart
@@ -124,7 +124,7 @@ class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
         fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
-        isNewMachine: false, // technically this is a new machine, so we should override the fragment?
+        isNewMachine: false,
         replaceHardware: true,
         robotConfig: savedRobotConfig, // pass the config that you want to apply to the new robot
       );

--- a/example/hotspot_provisioning/lib/replace_hardware_screen.dart
+++ b/example/hotspot_provisioning/lib/replace_hardware_screen.dart
@@ -149,7 +149,7 @@ class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
           }
           break;
         case RobotStatus.loading:
-          // we will never get here as the flow will timeout and the robot will be offline
+          // we will never get here as the flow will timeout and the statuse will be returned asoffline
           debugPrint('Robot status still loading.');
           break;
       }

--- a/example/hotspot_provisioning/lib/replace_hardware_screen.dart
+++ b/example/hotspot_provisioning/lib/replace_hardware_screen.dart
@@ -118,15 +118,15 @@ class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
     if (context.mounted) {
       final result = await HotspotProvisioningFlow.show(
         context,
-        robot: replacementRobot,
+        robot: replacementRobot, // Be sure to pass in a new robot that will be used as the replacement robot
         viam: viam,
-        mainPart: replacementMainPart,
+        mainPart: replacementMainPart, // Be sure to pass in the main part of the new robot
         fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
         isNewMachine: false,
         replaceHardware: true,
-        robotConfig: savedRobotConfig, // pass the config that you want to apply to the new robot
+        robotConfig: savedRobotConfig, // Be sure to pass in the config from the old robot that you want to apply to the new robot
       );
 
       if (result != null) {

--- a/example/hotspot_provisioning/lib/replace_hardware_screen.dart
+++ b/example/hotspot_provisioning/lib/replace_hardware_screen.dart
@@ -5,6 +5,7 @@ import 'package:viam_flutter_hotspot_provisioning_widget/viam_flutter_hotspot_pr
 import 'consts.dart';
 import 'offline_screen.dart';
 import 'online_screen.dart';
+import 'package:viam_sdk/src/utils.dart'; // ignore: implementation_imports
 
 enum _RobotStatus { online, offline, awaitingSetup, loading }
 
@@ -15,14 +16,14 @@ class _ListRobot {
   _ListRobot({required this.robot, required this.locationName});
 }
 
-class ReconnectRobotsScreen extends StatefulWidget {
-  const ReconnectRobotsScreen({super.key});
+class ReplaceHardwareScreen extends StatefulWidget {
+  const ReplaceHardwareScreen({super.key});
 
   @override
-  State<ReconnectRobotsScreen> createState() => _ReconnectRobotsScreenState();
+  State<ReplaceHardwareScreen> createState() => _ReplaceHardwareScreenState();
 }
 
-class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
+class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
   Viam? _viam;
   bool _isLoading = false;
   List<_ListRobot> _robots = [];
@@ -99,20 +100,33 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
     }
   }
 
+//  so bascially the user needs to provide the new replacement robot and the config from the old robot
+  Future<(Map<String, dynamic>, RobotPart)> getConfig(Robot robot) async {
+    _viam = await Viam.withApiKey(Consts.apiKeyId, Consts.apiKey);
+    final parts = await _viam!.appClient.listRobotParts(robot.id);
+    final mainPart = parts.firstWhere((element) => element.mainPart);
+    return (mainPart.robotConfig.toMap(), mainPart);
+  }
+
+  // This is the flow that will be used to replace the hardware of the existing robot
+  // 1. Get the config from our old robot so we can apply it to the new robot
+  // 2. Create a new robot to be used as the "replacement" robot
   void _goToHotspotProvisioningFlow(BuildContext context, Viam viam, Robot existingRobot) async {
-    final mainPart = (await viam.appClient.listRobotParts(existingRobot.id)).firstWhere((element) => element.mainPart);
+    final (savedRobotConfig, _) = await getConfig(existingRobot);
+    final (replacementRobot, replacementMainPart) = await createNewRobot(existingRobot, viam);
+
     if (context.mounted) {
       final result = await HotspotProvisioningFlow.show(
         context,
-        robot: existingRobot,
+        robot: replacementRobot,
         viam: viam,
-        mainPart: mainPart,
+        mainPart: replacementMainPart,
         fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
-        isNewMachine: false, // Don't override fragment for existing machine reconnection
-        replaceHardware: false,
-        robotConfig: null,
+        isNewMachine: false, // technically this is a new machine, so we should override the fragment?
+        replaceHardware: true,
+        robotConfig: savedRobotConfig, // pass the config that you want to apply to the new robot
       );
 
       if (result != null) {
@@ -130,6 +144,15 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
         debugPrint('No result from HotspotProvisioningFlow. The flow may have been cancelled.');
       }
     }
+  }
+
+  Future<(Robot, RobotPart)> createNewRobot(Robot existingRobot, Viam viam) async {
+    final replacementRobotname = '${existingRobot.name}-replacement';
+    final replacementRobotId = await viam.appClient.newMachine(replacementRobotname, existingRobot.location);
+    final parts = await viam.appClient.listRobotParts(replacementRobotId);
+    final replacementMainPart = parts.firstWhere((element) => element.mainPart);
+    final replacementRobot = await viam.appClient.getRobot(replacementRobotId);
+    return (replacementRobot, replacementMainPart);
   }
 
   @override

--- a/example/hotspot_provisioning/lib/start_screen.dart
+++ b/example/hotspot_provisioning/lib/start_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:viam_example_app/replace_hardware_screen.dart';
 import 'package:viam_flutter_hotspot_provisioning_widget/viam_flutter_hotspot_provisioning_widget.dart';
 import 'reconnect_machines_screen.dart';
 import 'provision_new_machine.dart';
@@ -21,6 +22,12 @@ class StartScreen extends StatelessWidget {
   void _goToProvisionNewMachineWithCredInputFlow(BuildContext context) {
     Navigator.of(context).push(MaterialPageRoute(
       builder: (context) => const ProvisionNewMachineScreen(promptForCredentials: true),
+    ));
+  }
+
+   void _goToReplaceHardwareFlow(BuildContext context) {
+    Navigator.of(context).push(MaterialPageRoute(
+      builder: (context) => const ReplaceHardwareScreen(),
     ));
   }
 
@@ -49,6 +56,11 @@ class StartScreen extends StatelessWidget {
             PrimaryButton(
               onPressed: () => _goToProvisionNewMachineWithCredInputFlow(context),
               text: 'Provision New Machine with Credentials',
+            ),
+            const SizedBox(height: 16),
+            PrimaryButton(
+              onPressed: () => _goToReplaceHardwareFlow(context),
+              text: 'Replace Hardware',
             ),
           ],
         ),

--- a/example/hotspot_provisioning/pubspec.yaml
+++ b/example/hotspot_provisioning/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.1.1
+  viam_sdk: ^0.10.0
   viam_flutter_hotspot_provisioning_widget:
     path: ../../
 

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -308,7 +308,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
-              Navigator.of(context).pop(); 
+              Navigator.of(context).pop();
               Navigator.of(context).pop();
             },
             child: const Text('Go Back'),

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -9,6 +9,8 @@ class HotspotProvisioningFlow extends StatefulWidget {
   final String? fragmentId;
   final bool promptForCredentials;
   final bool isNewMachine;
+  final bool replaceHardware;
+  final Map<String, dynamic>? robotConfig;
 
   const HotspotProvisioningFlow({
     super.key,
@@ -20,6 +22,8 @@ class HotspotProvisioningFlow extends StatefulWidget {
     this.fragmentId,
     this.promptForCredentials = false,
     required this.isNewMachine,
+    required this.replaceHardware,
+    this.robotConfig, // optional, for replacing hardware
   });
 
 // Static method to push this flow and get a result
@@ -33,6 +37,8 @@ class HotspotProvisioningFlow extends StatefulWidget {
     String? fragmentId,
     bool promptForCredentials = false,
     required bool isNewMachine,
+    required bool replaceHardware,
+    Map<String, dynamic>? robotConfig,
   }) {
     return Navigator.of(context).push<HotspotProvisioningResult?>(
       MaterialPageRoute(
@@ -45,6 +51,8 @@ class HotspotProvisioningFlow extends StatefulWidget {
           fragmentId: fragmentId,
           promptForCredentials: promptForCredentials,
           isNewMachine: isNewMachine,
+          replaceHardware: replaceHardware,
+          robotConfig: robotConfig,
         ),
       ),
     );
@@ -279,6 +287,8 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
                   onStatusDetermined: onConfirmationStatusDetermined,
                   fragmentId: _determinedFragmentId,
                   isNewMachine: widget.isNewMachine,
+                  replaceHardware: widget.replaceHardware,
+                  robotConfig: widget.robotConfig,
                 )
               ],
             ),

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -66,7 +66,6 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
   late final PageController _pageController;
   late final NetworkSelectionViewModel _networkSelectionViewModel;
   late final PasswordInputViewModel _passwordInputViewModel;
-  late final ConnectHotspotPrefixViewModel _connectHotspotPrefixViewModel;
   int _currentPage = 0;
   String? _determinedFragmentId;
   String? _userProvidedHotspotPrefix;
@@ -119,7 +118,6 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     _pageController.dispose();
     _networkSelectionViewModel.dispose();
     _passwordInputViewModel.dispose();
-    _connectHotspotPrefixViewModel.dispose();
     super.dispose();
   }
 

--- a/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
+++ b/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
@@ -8,12 +8,16 @@ class ConfirmationViewModel extends ChangeNotifier {
     required String? fragmentId,
     required RobotPart mainPart,
     required bool isNewMachine,
+    required bool replaceHardware,
+    required Map<String, dynamic>? robotConfig,
   })  : _viam = viam,
         _robot = robot,
         _fragmentId = fragmentId,
         _mainPart = mainPart,
         _onStatusDetermined = onStatusDetermined,
-        _isNewMachine = isNewMachine {
+        _isNewMachine = isNewMachine,
+        _replaceHardware = replaceHardware,
+        _robotConfig = robotConfig {
     _disconnectFromHotspot();
     _startCheckingOnline();
   }
@@ -24,6 +28,8 @@ class ConfirmationViewModel extends ChangeNotifier {
   final RobotPart _mainPart;
   final void Function(Robot robot, RobotStatus status) _onStatusDetermined;
   final bool _isNewMachine;
+  final bool _replaceHardware;
+  final Map<String, dynamic>? _robotConfig;
 
   Timer? _timer;
   RobotStatus _robotStatus = RobotStatus.loading;
@@ -62,6 +68,9 @@ class ConfirmationViewModel extends ChangeNotifier {
       if (_isNewMachine) {
         _performFragmentOverride(_viam, _fragmentId, _mainPart, _robot);
       }
+      if (_replaceHardware && _robotConfig != null) {
+        _applyRobotConfig(_viam, _mainPart, _robotConfig);
+      }
       // robot provisioning did not complete successfully and is offline
     } else if (_robotStatus == RobotStatus.offline) {
       _onStatusDetermined.call(_robot, RobotStatus.offline);
@@ -99,6 +108,15 @@ class ConfirmationViewModel extends ChangeNotifier {
       "fragments": [fragmentId]
     };
     await viam.appClient.updateRobotPart(robotPart.id, robot.name, config);
+  }
+
+  // Update the new robot's config with the saved config from the old robot
+  Future<void> _applyRobotConfig(Viam viam, RobotPart mainPart, Map<String, dynamic> savedRobotConfig) async {
+    try {
+      await viam.appClient.updateRobotPart(mainPart.id, mainPart.name, savedRobotConfig);
+    } catch (e) {
+      debugPrint('Error applying robotConfig: ${e.toString()}');
+    }
   }
 
   void _getRobotStatus() async {

--- a/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
+++ b/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
@@ -9,7 +9,7 @@ class ConfirmationViewModel extends ChangeNotifier {
     required RobotPart mainPart,
     required bool isNewMachine,
     required bool replaceHardware,
-    required Map<String, dynamic>? robotConfig,
+    Map<String, dynamic>? robotConfig,
   })  : _viam = viam,
         _robot = robot,
         _fragmentId = fragmentId,

--- a/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
+++ b/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
@@ -3,14 +3,17 @@ part of '../../../../../viam_flutter_hotspot_provisioning_widget.dart';
 enum RobotStatus { online, offline, loading }
 
 class ConfirmationScreen extends StatefulWidget {
-  const ConfirmationScreen(
-      {super.key,
-      required this.robot,
-      required this.viam,
-      required this.mainPart,
-      required this.onStatusDetermined,
-      this.fragmentId,
-      required this.isNewMachine});
+  const ConfirmationScreen({
+    super.key,
+    required this.robot,
+    required this.viam,
+    required this.mainPart,
+    required this.onStatusDetermined,
+    this.fragmentId,
+    required this.isNewMachine,
+    required this.replaceHardware,
+    required this.robotConfig,
+  });
 
   final Viam viam;
   final Robot robot;
@@ -18,6 +21,8 @@ class ConfirmationScreen extends StatefulWidget {
   final String? fragmentId;
   final void Function(Robot robot, RobotStatus status) onStatusDetermined;
   final bool isNewMachine;
+  final bool replaceHardware;
+  final Map<String, dynamic>? robotConfig;
 
   @override
   State<ConfirmationScreen> createState() => _ConfirmationScreenState();
@@ -36,6 +41,8 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
       fragmentId: widget.fragmentId,
       mainPart: widget.mainPart,
       isNewMachine: widget.isNewMachine,
+      replaceHardware: widget.replaceHardware,
+      robotConfig: widget.robotConfig,
     );
   }
 

--- a/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
+++ b/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
@@ -12,7 +12,7 @@ class ConfirmationScreen extends StatefulWidget {
     this.fragmentId,
     required this.isNewMachine,
     required this.replaceHardware,
-    required this.robotConfig,
+    this.robotConfig,
   });
 
   final Viam viam;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
    flutter:
     sdk: flutter
    plugin_wifi_connect: ^2.0.1
-   viam_sdk: ^0.6.6
+   viam_sdk: ^0.10.0
    permission_handler: ^12.0.0+1
    flutter_platform_widgets: ^7.0.1
    provider: ^6.1.5


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-9642) - This PR sets up the "replace hardware" flow in the provisioning widget. This flow is a mix between the reconnect flow and the new machine flow. The user will still select an old machine from the list of machines, however, they are required to pass in the new "replacement" robot into the flow in order to actually provision this new robot to the new machine. 

I added many details about how this flow works in the readMe's.