### PR TITLE
Change name from isNewMachine to overrideFragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ final result = await HotspotProvisioningFlow.show(
   hotspotPrefix: 'your-hotspot-prefix',  // Must match viam-defaults.json & must be at least 3 characters long 
   hotspotPassword: 'your-hotspot-password', // Must match viam-defaults.json
   promptForCredentials: false, // Use hardcoded credentials
-  isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  overrideFragment: true, // Set to true for new machines, false for reconnecting existing machines
   replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
   robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
@@ -133,7 +133,7 @@ final result = await HotspotProvisioningFlow.show(
   mainPart: mainPart,
   fragmentId: 'your-fragment-id',
   promptForCredentials: true, // This will show a credential input screen
-  isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  overrideFragment: true, // Set to true for new machines, false for reconnecting existing machines
   replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
   robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
@@ -166,7 +166,7 @@ final result = await HotspotProvisioningFlow.show(
   hotspotPrefix: 'your-prefix',
   hotspotPassword: 'your-password',
   promptForCredentials: false, // Use hardcoded credentials
-  isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  overrideFragment: true, // Set to true for new machines, false for reconnecting existing machines
   replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
   robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
@@ -182,7 +182,7 @@ final result = await HotspotProvisioningFlow.show(
   viam: viam,
   mainPart: mainPart,
   promptForCredentials: true, // This will show a credential input screen
-  isNewMachine: true, // Set to true for new machines, false for reconnecting existing machines
+  overrideFragment: true, // Set to true for new machines, false for reconnecting existing machines
   replaceHardware: false, // Set to true when replacing hardware and want to apply saved robot config
   robotConfig: null, // Optional, pass saved robot config when replaceHardware is true
 );
@@ -213,7 +213,7 @@ final result = await HotspotProvisioningFlow.show(
   hotspotPrefix: 'your-hotspot-prefix',
   hotspotPassword: 'your-hotspot-password',
   promptForCredentials: false,
-  isNewMachine: false,
+  overrideFragment: false,
   replaceHardware: true, // Enable hardware replacement mode
   robotConfig: savedRobotConfig, // Pass the saved configuration
 );
@@ -231,7 +231,7 @@ What you need to pass into the widget:
 - `hotspotPrefix`: The SSID prefix for the robot's hotspot. This prefix **must match** the prefix you set in the viam-defaults.json. **The hotspot prefix must be at least 3 characters long.** (Optional when `promptForCredentials` is true)
 - `hotspotPassword`: The password for the robot's hotspot. This password **must match** the password you set in the viam-defaults.json. (Optional when `promptForCredentials` is true)
 - `promptForCredentials`: Whether to show a credential input screen for the user to enter hotspot prefix and password. When true, `hotspotPrefix` and `hotspotPassword` are optional.
-- `isNewMachine`: Whether this is a new machine being provisioned for the first time. Set to `true` for new machines, `false` for reconnecting existing machines. When `true`, the fragment override will be performed after successful provisioning.
+- `overrideFragment`: Whether this is a new machine being provisioned for the first time. Set to `true` for new machines, `false` for reconnecting existing machines. When `true`, the fragment override will be performed after successful provisioning.
 - `replaceHardware`: Whether you are replacing hardware and want to apply a saved robot configuration. Set to `true` when replacing hardware, `false` otherwise.
 - `robotConfig`: Optional saved robot configuration to apply when `replaceHardware` is `true`. Pass the configuration from the old robot that you want to apply to the new robot. Can be omitted when `replaceHardware` is `false`.  
 

--- a/example/hotspot_provisioning/lib/provision_new_machine.dart
+++ b/example/hotspot_provisioning/lib/provision_new_machine.dart
@@ -88,7 +88,7 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
             mainPart: mainPart,
             fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
             promptForCredentials: true,
-            isNewMachine: true, // Override fragment for new machine provisioning
+            overrideFragment: true, // Override fragment for new machine provisioning
             replaceHardware: false,
             robotConfig: null,
           );
@@ -102,7 +102,7 @@ class _ProvisionNewMachineScreenState extends State<ProvisionNewMachineScreen> {
             hotspotPrefix: Consts.hotspotPrefix, // This must be at least 3 characters long
             hotspotPassword: Consts.hotspotPassword,
             promptForCredentials: false,
-            isNewMachine: true, // Override fragment for new machine provisioning
+            overrideFragment: true, // Override fragment for new machine provisioning
             replaceHardware: false,
             robotConfig: null,
           );

--- a/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
+++ b/example/hotspot_provisioning/lib/reconnect_machines_screen.dart
@@ -110,7 +110,7 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
         fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
-        isNewMachine: false, // Don't override fragment for existing machine reconnection
+        overrideFragment: false, // Don't override fragment for existing machine reconnection
         replaceHardware: false,
         robotConfig: null,
       );

--- a/example/hotspot_provisioning/lib/replace_hardware_screen.dart
+++ b/example/hotspot_provisioning/lib/replace_hardware_screen.dart
@@ -124,7 +124,7 @@ class _ReplaceHardwareScreenState extends State<ReplaceHardwareScreen> {
         fragmentId: null, // Optional, if null, the fragmentId will be read from the device.
         hotspotPrefix: Consts.hotspotPrefix,
         hotspotPassword: Consts.hotspotPassword,
-        isNewMachine: false,
+        overrideFragment: false,
         replaceHardware: true,
         robotConfig: savedRobotConfig, // Be sure to pass in the config from the old robot that you want to apply to the new robot
       );

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -8,7 +8,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
   final String? hotspotPassword;
   final String? fragmentId;
   final bool promptForCredentials;
-  final bool isNewMachine;
+  final bool overrideFragment;
   final bool replaceHardware;
   final Map<String, dynamic>? robotConfig;
 
@@ -21,7 +21,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
     this.hotspotPassword,
     this.fragmentId,
     this.promptForCredentials = false,
-    required this.isNewMachine,
+    required this.overrideFragment,
     required this.replaceHardware,
     this.robotConfig, // optional, for replacing hardware
   });
@@ -36,7 +36,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
     String? hotspotPassword,
     String? fragmentId,
     bool promptForCredentials = false,
-    required bool isNewMachine,
+    required bool overrideFragment,
     required bool replaceHardware,
     Map<String, dynamic>? robotConfig,
   }) {
@@ -50,7 +50,7 @@ class HotspotProvisioningFlow extends StatefulWidget {
           hotspotPassword: hotspotPassword,
           fragmentId: fragmentId,
           promptForCredentials: promptForCredentials,
-          isNewMachine: isNewMachine,
+          overrideFragment: overrideFragment,
           replaceHardware: replaceHardware,
           robotConfig: robotConfig,
         ),
@@ -286,7 +286,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
                   mainPart: widget.mainPart,
                   onStatusDetermined: onConfirmationStatusDetermined,
                   fragmentId: _determinedFragmentId,
-                  isNewMachine: widget.isNewMachine,
+                  overrideFragment: widget.overrideFragment,
                   replaceHardware: widget.replaceHardware,
                   robotConfig: widget.robotConfig,
                 )

--- a/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
+++ b/lib/src/screens/confirmation.dart/view_model/confirmation_view_model.dart
@@ -7,7 +7,7 @@ class ConfirmationViewModel extends ChangeNotifier {
     required void Function(Robot robot, RobotStatus status) onStatusDetermined,
     required String? fragmentId,
     required RobotPart mainPart,
-    required bool isNewMachine,
+    required bool overrideFragment,
     required bool replaceHardware,
     Map<String, dynamic>? robotConfig,
   })  : _viam = viam,
@@ -15,7 +15,7 @@ class ConfirmationViewModel extends ChangeNotifier {
         _fragmentId = fragmentId,
         _mainPart = mainPart,
         _onStatusDetermined = onStatusDetermined,
-        _isNewMachine = isNewMachine,
+        _overrideFragment = overrideFragment,
         _replaceHardware = replaceHardware,
         _robotConfig = robotConfig {
     _disconnectFromHotspot();
@@ -27,7 +27,7 @@ class ConfirmationViewModel extends ChangeNotifier {
   final String? _fragmentId;
   final RobotPart _mainPart;
   final void Function(Robot robot, RobotStatus status) _onStatusDetermined;
-  final bool _isNewMachine;
+  final bool _overrideFragment;
   final bool _replaceHardware;
   final Map<String, dynamic>? _robotConfig;
 
@@ -65,7 +65,7 @@ class ConfirmationViewModel extends ChangeNotifier {
     if (_robotStatus == RobotStatus.online) {
       _onStatusDetermined.call(_robot, RobotStatus.online);
       _timer?.cancel();
-      if (_isNewMachine) {
+      if (_overrideFragment) {
         _performFragmentOverride(_viam, _fragmentId, _mainPart, _robot);
       }
       if (_replaceHardware && _robotConfig != null) {

--- a/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
+++ b/lib/src/screens/confirmation.dart/widgets/confirmation_screen.dart
@@ -10,7 +10,7 @@ class ConfirmationScreen extends StatefulWidget {
     required this.mainPart,
     required this.onStatusDetermined,
     this.fragmentId,
-    required this.isNewMachine,
+    required this.overrideFragment,
     required this.replaceHardware,
     this.robotConfig,
   });
@@ -20,7 +20,7 @@ class ConfirmationScreen extends StatefulWidget {
   final RobotPart mainPart;
   final String? fragmentId;
   final void Function(Robot robot, RobotStatus status) onStatusDetermined;
-  final bool isNewMachine;
+  final bool overrideFragment;
   final bool replaceHardware;
   final Map<String, dynamic>? robotConfig;
 
@@ -40,7 +40,7 @@ class _ConfirmationScreenState extends State<ConfirmationScreen> {
       onStatusDetermined: widget.onStatusDetermined,
       fragmentId: widget.fragmentId,
       mainPart: widget.mainPart,
-      isNewMachine: widget.isNewMachine,
+      overrideFragment: widget.overrideFragment,
       replaceHardware: widget.replaceHardware,
       robotConfig: widget.robotConfig,
     );


### PR DESCRIPTION
The name isNewMachine does not hold anymore because when we replace a machine we actually don't want to override the fragment but technically we are creating a new machine, so changing the name just helps clarity here