### PR TITLE
[APP-9720] [Hotspot prov widget] remove the "done" button on the setting up device screen

### DIFF
--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -169,15 +169,12 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     switch (_currentPage) {
       case 0:
         title = "Connect to Device Hotspot";
-        break;
       case 1:
         title = "Connect to your vessel's Wi-Fi";
         actions = _buildRefreshAction(context, networkSelectionViewModel);
-        break;
       case 2:
         title = 'Connect to Wi-Fi';
         actions = _buildDoneAction(context, passwordInputViewModel);
-        break;
       case 3:
         return _buildConnectingAppBar(context);
     }
@@ -194,18 +191,14 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     switch (_currentPage) {
       case 0:
         title = "Enter Hotspot Credentials";
-        break;
       case 1:
         title = "Connect to Device Hotspot";
-        break;
       case 2:
         title = "Connect to your vessel's Wi-Fi";
         actions = _buildRefreshAction(context, networkSelectionViewModel);
-        break;
       case 3:
         title = 'Connect to Wi-Fi';
         actions = _buildDoneAction(context, passwordInputViewModel);
-        break;
       case 4:
         return _buildConnectingAppBar(context);
     }

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -304,6 +304,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
                     ),
                   ),
                 NetworkSelectionScreen(
+                  viewModel: _networkSelectionViewModel,
                   viam: widget.viam,
                   onSelectNetwork: (network) {
                     _passwordInputViewModel.network = network;

--- a/lib/src/flow/hotspot_provisioning_flow.dart
+++ b/lib/src/flow/hotspot_provisioning_flow.dart
@@ -168,52 +168,85 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
 
     switch (_currentPage) {
       case 0:
-        if (widget.promptForCredentials) {
-          title = "Enter Hotspot Credentials";
-        } else {
-          title = "Connect to Device Hotspot";
-        }
+        title = "Connect to Device Hotspot";
+        break;
+      case 1:
+        title = "Connect to your vessel's Wi-Fi";
+        actions = _buildRefreshAction(context, networkSelectionViewModel);
+        break;
+      case 2:
+        title = 'Connect to Wi-Fi';
+        actions = _buildDoneAction(context, passwordInputViewModel);
+        break;
+      case 3:
+        return _buildConnectingAppBar(context);
+    }
+
+    return _buildStandardAppBar(context, title, actions);
+  }
+
+  AppBar _buildAppBarWithPromptForCredentials(BuildContext context) {
+    final passwordInputViewModel = context.watch<PasswordInputViewModel>();
+    final networkSelectionViewModel = context.watch<NetworkSelectionViewModel>();
+    String title = "";
+    List<Widget> actions = [];
+
+    switch (_currentPage) {
+      case 0:
+        title = "Enter Hotspot Credentials";
         break;
       case 1:
         title = "Connect to Device Hotspot";
         break;
       case 2:
         title = "Connect to your vessel's Wi-Fi";
-        actions = [
-          IconButton(
-            icon: Icon(Icons.refresh, color: Theme.of(context).colorScheme.onSurface, size: 24.0),
-            onPressed: () => networkSelectionViewModel.getNetworks(refresh: true),
-          )
-        ];
+        actions = _buildRefreshAction(context, networkSelectionViewModel);
         break;
       case 3:
         title = 'Connect to Wi-Fi';
-        final canSubmit = passwordInputViewModel.areNetworkCredentialsValid;
-        actions = [
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.all(6.0),
-              child: GestureDetector(
-                onTap: canSubmit ? () => passwordInputViewModel.submitPassword(context) : null,
-                child: passwordInputViewModel.loading
-                    ? const CupertinoActivityIndicator()
-                    : Text(
-                        "Done",
-                        style: TextStyle(
-                          fontSize: 14.0,
-                          fontWeight: FontWeight.bold,
-                          color: canSubmit ? const Color(0xFF0EB4CE) : Colors.grey,
-                        ),
-                      ),
-              ),
-            ),
-          ),
-        ];
+        actions = _buildDoneAction(context, passwordInputViewModel);
         break;
       case 4:
-        return AppBar(backgroundColor: Theme.of(context).colorScheme.surface, elevation: 0, automaticallyImplyLeading: false);
+        return _buildConnectingAppBar(context);
     }
 
+    return _buildStandardAppBar(context, title, actions);
+  }
+
+  List<Widget> _buildRefreshAction(BuildContext context, NetworkSelectionViewModel networkSelectionViewModel) {
+    return [
+      IconButton(
+        icon: Icon(Icons.refresh, color: Theme.of(context).colorScheme.onSurface, size: 24.0),
+        onPressed: () => networkSelectionViewModel.getNetworks(refresh: true),
+      )
+    ];
+  }
+
+  List<Widget> _buildDoneAction(BuildContext context, PasswordInputViewModel passwordInputViewModel) {
+    final canSubmit = passwordInputViewModel.areNetworkCredentialsValid;
+    return [
+      Center(
+        child: Padding(
+          padding: const EdgeInsets.all(6.0),
+          child: GestureDetector(
+            onTap: canSubmit ? () => passwordInputViewModel.submitPassword(context) : null,
+            child: passwordInputViewModel.loading
+                ? const CupertinoActivityIndicator()
+                : Text(
+                    "Done",
+                    style: TextStyle(
+                      fontSize: 14.0,
+                      fontWeight: FontWeight.bold,
+                      color: canSubmit ? const Color(0xFF0EB4CE) : Colors.grey,
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    ];
+  }
+
+  AppBar _buildStandardAppBar(BuildContext context, String title, List<Widget> actions) {
     return AppBar(
       title: Text(title, style: TextStyle(color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0, fontWeight: FontWeight.w500)),
       backgroundColor: Theme.of(context).colorScheme.surface,
@@ -233,6 +266,10 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
     );
   }
 
+  AppBar _buildConnectingAppBar(BuildContext context) {
+    return AppBar(backgroundColor: Theme.of(context).colorScheme.surface, elevation: 0, automaticallyImplyLeading: false);
+  }
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
@@ -243,7 +280,7 @@ class _HotspotProvisioningFlowState extends State<HotspotProvisioningFlow> {
       child: Builder(builder: (context) {
         return Scaffold(
           backgroundColor: Theme.of(context).colorScheme.surface,
-          appBar: _buildAppBar(context),
+          appBar: widget.promptForCredentials ? _buildAppBarWithPromptForCredentials(context) : _buildAppBar(context),
           body: SafeArea(
             child: PageView(
               controller: _pageController,

--- a/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
+++ b/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
@@ -4,12 +4,14 @@ class NetworkSelectionScreen extends StatefulWidget {
   final void Function(NetworkInfo) onSelectNetwork;
   final VoidCallback onManualEntry;
   final Viam viam;
+  final NetworkSelectionViewModel viewModel;
 
   const NetworkSelectionScreen({
     super.key,
     required this.onSelectNetwork,
     required this.onManualEntry,
     required this.viam,
+    required this.viewModel,
   });
 
   @override
@@ -23,23 +25,23 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
     // Initialize after the frame is built
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        final viewModel = context.read<NetworkSelectionViewModel>();
-        viewModel.initialize();
+        widget.viewModel.initialize();
       }
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<NetworkSelectionViewModel>(
-      builder: (context, viewModel, child) {
-        if (viewModel.loadingNetworks) {
+    return ListenableBuilder(
+      listenable: widget.viewModel,
+      builder: (context, child) {
+        if (widget.viewModel.loadingNetworks) {
           return const NoContentWidget(
             titleString: "Scanning...",
             bodyString: "Looking for visible networks...",
           );
         }
-        if (viewModel.machineVisibleNetworks.isEmpty) {
+        if (widget.viewModel.machineVisibleNetworks.isEmpty) {
           return NoContentWidget(
               icon: const Icon(Icons.error, color: Colors.red),
               buttons: [
@@ -58,7 +60,7 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                   ),
                 ),
                 FilledButton(
-                  onPressed: viewModel.loadingNetworks ? null : () => viewModel.getNetworks(refresh: true),
+                  onPressed: widget.viewModel.loadingNetworks ? null : () => widget.viewModel.getNetworks(refresh: true),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -95,20 +97,20 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                   color: Theme.of(context).colorScheme.surface,
                   child: ListView.builder(
                     shrinkWrap: true,
-                    itemCount: viewModel.machineVisibleNetworks.length,
+                    itemCount: widget.viewModel.machineVisibleNetworks.length,
                     itemBuilder: (BuildContext context, int index) {
                       return GestureDetector(
-                        onTap: () => widget.onSelectNetwork(viewModel.machineVisibleNetworks[index]),
+                        onTap: () => widget.onSelectNetwork(widget.viewModel.machineVisibleNetworks[index]),
                         child: ProvisioningListItem(
-                          textString: viewModel.machineVisibleNetworks[index].ssid,
+                          textString: widget.viewModel.machineVisibleNetworks[index].ssid,
                           leading: Icon(
-                            viewModel.signalToIcon(viewModel.machineVisibleNetworks[index].signal),
+                            widget.viewModel.signalToIcon(widget.viewModel.machineVisibleNetworks[index].signal),
                             size: 24.0,
                             color: Colors.grey,
                           ),
                           add: false,
                           trailing: Icon(
-                            viewModel.securityToIcon(viewModel.machineVisibleNetworks[index].security),
+                            widget.viewModel.securityToIcon(widget.viewModel.machineVisibleNetworks[index].security),
                             size: 20.0,
                             color: Colors.grey,
                           ),

--- a/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
+++ b/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
@@ -17,42 +17,29 @@ class NetworkSelectionScreen extends StatefulWidget {
 }
 
 class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
-  NetworkSelectionViewModel? _viewModel;
-
   @override
   void initState() {
     super.initState();
-    _viewModel = NetworkSelectionViewModel(viam: widget.viam);
     // Initialize after the frame is built
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        _viewModel?.initialize();
+        final viewModel = context.read<NetworkSelectionViewModel>();
+        viewModel.initialize();
       }
     });
   }
 
   @override
-  void dispose() {
-    _viewModel?.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (_viewModel == null) {
-      return const SizedBox.shrink(); // or some loading indicator
-    }
-
-    return ListenableBuilder(
-      listenable: _viewModel!,
-      builder: (context, _) {
-        if (_viewModel!.loadingNetworks) {
+    return Consumer<NetworkSelectionViewModel>(
+      builder: (context, viewModel, child) {
+        if (viewModel.loadingNetworks) {
           return const NoContentWidget(
             titleString: "Scanning...",
             bodyString: "Looking for visible networks...",
           );
         }
-        if (_viewModel!.machineVisibleNetworks.isEmpty) {
+        if (viewModel.machineVisibleNetworks.isEmpty) {
           return NoContentWidget(
               icon: const Icon(Icons.error, color: Colors.red),
               buttons: [
@@ -71,7 +58,7 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                   ),
                 ),
                 FilledButton(
-                  onPressed: _viewModel!.loadingNetworks ? null : () => _viewModel!.getNetworks(refresh: true),
+                  onPressed: viewModel.loadingNetworks ? null : () => viewModel.getNetworks(refresh: true),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -108,20 +95,20 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                   color: Theme.of(context).colorScheme.surface,
                   child: ListView.builder(
                     shrinkWrap: true,
-                    itemCount: _viewModel!.machineVisibleNetworks.length,
+                    itemCount: viewModel.machineVisibleNetworks.length,
                     itemBuilder: (BuildContext context, int index) {
                       return GestureDetector(
-                        onTap: () => widget.onSelectNetwork(_viewModel!.machineVisibleNetworks[index]),
+                        onTap: () => widget.onSelectNetwork(viewModel.machineVisibleNetworks[index]),
                         child: ProvisioningListItem(
-                          textString: _viewModel!.machineVisibleNetworks[index].ssid,
+                          textString: viewModel.machineVisibleNetworks[index].ssid,
                           leading: Icon(
-                            _viewModel!.signalToIcon(_viewModel!.machineVisibleNetworks[index].signal),
+                            viewModel.signalToIcon(viewModel.machineVisibleNetworks[index].signal),
                             size: 24.0,
                             color: Colors.grey,
                           ),
                           add: false,
                           trailing: Icon(
-                            _viewModel!.securityToIcon(_viewModel!.machineVisibleNetworks[index].security),
+                            viewModel.securityToIcon(viewModel.machineVisibleNetworks[index].security),
                             size: 20.0,
                             color: Colors.grey,
                           ),

--- a/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
+++ b/lib/src/screens/password_input.dart/view_model/password_input_view_model.dart
@@ -24,7 +24,7 @@ class PasswordInputViewModel extends ChangeNotifier {
 
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _ssidController = TextEditingController();
-  bool _obscureText = true;
+  bool _obscureText = false;
   bool _loading = false;
   NetworkInfo? _network;
 


### PR DESCRIPTION
(https://viam.atlassian.net/browse/APP-9720) - This PR fixes the app bar that shows up at the top of provisioning flow. Previously we were seeing the wrong buttons at the top of the screen during the wrong parts of the flow, for example the "Done" button was showing up on the page after the user already submitted their wifi password. The reason for this was because the promptForCredentials screen was throwing off the switch statement. I have created two diff AppBar widgets now - one for when the user is entering credentials and one for when the user is not entering. 

Flyby; the view model in the network selection screen was never actually being set. 

Flyby; The wifi password is hidden by default when the user types, but we want to make it not hidden so that the user can see when they type it in 