### PR TITLE
Follow up to "Update colors to be non-hardcoded"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.0.17
+- Follow up to "Update colors to be non-hardcoded" by @jckras in https://github.com/viamrobotics/viam_flutter_hotspot_provisioning_widget/pull/48
 ## 0.0.16
 - Update colors to be non-hardcoded by @jckras in https://github.com/viamrobotics/viam_flutter_hotspot_provisioning_widget/pull/46
 - [APP-9720] [Hotspot prov widget] remove the "done" button on the setting up device screen by @jckras in https://github.com/viamrobotics/viam_flutter_hotspot_provisioning_widget/pull/44

--- a/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
+++ b/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
@@ -43,7 +43,7 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
         }
         if (widget.viewModel.machineVisibleNetworks.isEmpty) {
           return NoContentWidget(
-              icon:  Icon(Icons.error, color: Theme.of(context).colorScheme.error),
+              icon: Icon(Icons.error, color: Theme.of(context).colorScheme.error),
               buttons: [
                 FilledButton(
                   onPressed: () {
@@ -125,14 +125,6 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                 padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
                 child: Center(
                   child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Theme.of(context).colorScheme.primary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(24.0),
-                      ),
-                      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
-                      elevation: 0,
-                    ),
                     onPressed: () {
                       showDialog(
                         context: context,
@@ -143,7 +135,6 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                     },
                     child: Text(
                       "My network isn't showing up",
-                      style: TextStyle(color: Theme.of(context).colorScheme.onPrimary, fontWeight: FontWeight.w500),
                     ),
                   ),
                 ),

--- a/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
+++ b/lib/src/screens/network_selection.dart/widgets/network_selection_screen.dart
@@ -125,6 +125,13 @@ class _NetworkSelectionScreenState extends State<NetworkSelectionScreen> {
                 padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
                 child: Center(
                   child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(24.0),
+                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
+                      elevation: 0,
+                    ),
                     onPressed: () {
                       showDialog(
                         context: context,

--- a/lib/src/screens/shared_widgets/pill_button.dart
+++ b/lib/src/screens/shared_widgets/pill_button.dart
@@ -19,7 +19,6 @@ class PillButton extends StatelessWidget {
     return TextButton(
       style: ButtonStyle(
         shape: WidgetStatePropertyAll(RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0))),
-        backgroundColor: WidgetStatePropertyAll(enabled == null || !enabled! ? Theme.of(context).disabledColor : Theme.of(context).colorScheme.primary),
       ),
       onPressed: onPressed,
       child: Row(

--- a/lib/src/screens/shared_widgets/primary_button.dart
+++ b/lib/src/screens/shared_widgets/primary_button.dart
@@ -16,22 +16,13 @@ class PrimaryButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return FilledButton(
       onPressed: (isLoading || onPressed == null) ? null : onPressed,
-      style: OutlinedButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
       child: isLoading
           ? SizedBox(
               width: 20,
               height: 20,
-              child: CircularProgressIndicator.adaptive(
-                backgroundColor: Theme.of(context).colorScheme.onPrimary,
-              ),
+              child: CircularProgressIndicator.adaptive(),
             )
-          : Text(
-              text,
-              style: TextStyle(
-                fontWeight: FontWeight.w500,
-                color: onPressed != null ? Theme.of(context).colorScheme.onPrimary : Theme.of(context).disabledColor,
-              ),
-            ),
+          : Text(text),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: viam_flutter_hotspot_provisioning_widget
 description: "A Viam Flutter Hotspot Provisioning Widget."
-version: 0.0.16
+version: 0.0.17
 repository: https://github.com/viamrobotics/viam_flutter_hotspot_provisioning_widget
 homepage: https://www.viam.com/
 


### PR DESCRIPTION
Forgot to include when removing hardcoded colors in previous PR. This just removes the custom colors from widget so that it will inherit from the app that it is in. 
