### PR TITLE
Fall back to reachability check when hotspot fails to join

### DIFF
--- a/lib/src/data/repositories/hotspot_provisioning_repository.dart
+++ b/lib/src/data/repositories/hotspot_provisioning_repository.dart
@@ -15,6 +15,17 @@ class HotspotProvisioningRepository {
     return await viam.provisioningClient.getSmartMachineStatus();
   }
 
+  // Returns true if the device's provisioning service responds, regardless of the connected SSID
+  Future<bool> isDeviceReachable() async {
+    try {
+      await getSmartMachineStatus();
+      return true;
+    } catch (e) {
+      debugPrint('Device not reachable on current network: $e');
+      return false;
+    }
+  }
+
   Future<void> setSmartMachineCredentials({
     required String id,
     required String secret,

--- a/lib/src/data/repositories/hotspot_provisioning_repository.dart
+++ b/lib/src/data/repositories/hotspot_provisioning_repository.dart
@@ -15,10 +15,13 @@ class HotspotProvisioningRepository {
     return await viam.provisioningClient.getSmartMachineStatus();
   }
 
-  // Returns true if the device's provisioning service responds, regardless of the connected SSID
-  Future<bool> isDeviceReachable() async {
+  // Returns true if the device's provisioning service responds, regardless of the connected SSID.
+  // The underlying gRPC call has no deadline of its own, so we bound it here: if the device isn't
+  // on the current network the connection can hang indefinitely rather than throwing, which would
+  // otherwise leave the UI spinning forever.
+  Future<bool> isDeviceReachable({Duration timeout = const Duration(seconds: 10)}) async {
     try {
-      await getSmartMachineStatus();
+      await getSmartMachineStatus().timeout(timeout);
       return true;
     } catch (e) {
       debugPrint('Device not reachable on current network: $e');

--- a/lib/src/screens/connect_hotspot_prefix/view_model/connect_hotspot_prefix_view_model.dart
+++ b/lib/src/screens/connect_hotspot_prefix/view_model/connect_hotspot_prefix_view_model.dart
@@ -147,12 +147,20 @@ class ConnectHotspotPrefixViewModel extends ChangeNotifier {
         setConnectedToHotspot(true);
         findProvisionedMachine();
       } else {
-        setConnectedToHotspot(false);
-        if (Platform.isIOS) {
-          setIsAttemptingConnectionToHotspot(false);
-          setFailedToConnectToHotspot(true);
-        }
+        await _handleConnectionFailure();
       }
+    } else {
+      await _handleConnectionFailure();
+    }
+  }
+
+  // Called when we couldn't auto-join the hotspot by prefix. Before failing, check if the device is
+  // already reachable on the current network, in case the user joined a non-matching SSID manually.
+  Future<void> _handleConnectionFailure() async {
+    if (await repository.isDeviceReachable()) {
+      debugPrint('Hotspot prefix did not match, but device is reachable on the current network. Continuing.');
+      setConnectedToHotspot(true);
+      findProvisionedMachine();
     } else {
       setConnectedToHotspot(false);
       if (Platform.isIOS) {

--- a/test/data/repositories/hotspot_provisioning_repository_test.dart
+++ b/test/data/repositories/hotspot_provisioning_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -65,6 +67,16 @@ void main() {
     test('returns false when getSmartMachineStatus throws', () async {
       when(mockProvisioningClient.getSmartMachineStatus()).thenAnswer((_) async => throw Exception('unreachable'));
       expect(await hotspotProvisioningRepository.isDeviceReachable(), isFalse);
+    });
+
+    test('returns false when getSmartMachineStatus hangs past the timeout', () async {
+      // Simulate the device not being on the network: the gRPC call never completes.
+      when(mockProvisioningClient.getSmartMachineStatus())
+          .thenAnswer((_) => Completer<GetSmartMachineStatusResponse>().future);
+      expect(
+        await hotspotProvisioningRepository.isDeviceReachable(timeout: const Duration(milliseconds: 50)),
+        isFalse,
+      );
     });
   });
 

--- a/test/data/repositories/hotspot_provisioning_repository_test.dart
+++ b/test/data/repositories/hotspot_provisioning_repository_test.dart
@@ -56,6 +56,18 @@ void main() {
     });
   });
 
+  group('isDeviceReachable', () {
+    test('returns true when getSmartMachineStatus succeeds', () async {
+      when(mockProvisioningClient.getSmartMachineStatus()).thenAnswer((_) async => GetSmartMachineStatusResponse());
+      expect(await hotspotProvisioningRepository.isDeviceReachable(), isTrue);
+    });
+
+    test('returns false when getSmartMachineStatus throws', () async {
+      when(mockProvisioningClient.getSmartMachineStatus()).thenAnswer((_) async => throw Exception('unreachable'));
+      expect(await hotspotProvisioningRepository.isDeviceReachable(), isFalse);
+    });
+  });
+
   group('setSmartMachineCredentials', () {
     test('setSmartMachineCredentials calls the setSmartMachineCredentials method on the provisioning client', () async {
       when(mockProvisioningClient.setSmartMachineCredentials(

--- a/test/mocks/generate_mocks.mocks.dart
+++ b/test/mocks/generate_mocks.mocks.dart
@@ -493,10 +493,13 @@ class MockHotspotProvisioningRepository extends _i1.Mock
       ) as _i8.Future<_i2.GetSmartMachineStatusResponse>);
 
   @override
-  _i8.Future<bool> isDeviceReachable() => (super.noSuchMethod(
+  _i8.Future<bool> isDeviceReachable(
+          {Duration? timeout = const Duration(seconds: 10)}) =>
+      (super.noSuchMethod(
         Invocation.method(
           #isDeviceReachable,
           [],
+          {#timeout: timeout},
         ),
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);

--- a/test/mocks/generate_mocks.mocks.dart
+++ b/test/mocks/generate_mocks.mocks.dart
@@ -493,6 +493,15 @@ class MockHotspotProvisioningRepository extends _i1.Mock
       ) as _i8.Future<_i2.GetSmartMachineStatusResponse>);
 
   @override
+  _i8.Future<bool> isDeviceReachable() => (super.noSuchMethod(
+        Invocation.method(
+          #isDeviceReachable,
+          [],
+        ),
+        returnValue: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
+
+  @override
   _i8.Future<void> setSmartMachineCredentials({
     required String? id,
     required String? secret,

--- a/test/screens/connect_hotspot_prefix/view_model/connect_hotspot_prefix_view_model_test.dart
+++ b/test/screens/connect_hotspot_prefix/view_model/connect_hotspot_prefix_view_model_test.dart
@@ -13,6 +13,8 @@ void main() {
 
   setUp(() {
     mockHotspotProvisioningRepository = MockHotspotProvisioningRepository();
+    // Default to unreachable; fallback tests override with true
+    when(mockHotspotProvisioningRepository.isDeviceReachable()).thenAnswer((_) async => false);
     connectHotspotPrefixViewModel = ConnectHotspotPrefixViewModel(
       hotspotPrefix: 'test-prefix',
       hotspotPassword: 'test-password',
@@ -266,6 +268,76 @@ void main() {
         expect(connectHotspotPrefixViewModel.failedToConnectToHotspot, isTrue);
       } else {
         // Android uses native dialogs, doesn't set these flags
+        expect(connectHotspotPrefixViewModel.failedToConnectToHotspot, isFalse);
+      }
+    });
+
+    test('should proceed to provisioning when prefix join fails but device is reachable', () async {
+      when(mockHotspotProvisioningRepository.getCurrentSSID()).thenAnswer((_) async => 'random-old-ssid');
+      when(mockHotspotProvisioningRepository.connectToSecureNetworkByPrefix(
+        prefix: anyNamed('prefix'),
+        password: anyNamed('password'),
+        isWep: anyNamed('isWep'),
+        isWpa3: anyNamed('isWpa3'),
+        saveNetwork: anyNamed('saveNetwork'),
+      )).thenAnswer((_) async => false);
+      when(mockHotspotProvisioningRepository.isDeviceReachable()).thenAnswer((_) async => true);
+
+      connectHotspotPrefixViewModel.connectToHotspot();
+
+      // Wait for async operations to complete
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      verify(mockHotspotProvisioningRepository.isDeviceReachable()).called(1);
+      expect(connectHotspotPrefixViewModel.connectedToHotspot, isTrue);
+      expect(connectHotspotPrefixViewModel.failedToConnectToHotspot, isFalse);
+      expect(connectHotspotPrefixViewModel.pollingForMachine, isTrue);
+    });
+
+    test('should proceed to provisioning when connected SSID does not match prefix but device is reachable', () async {
+      when(mockHotspotProvisioningRepository.getCurrentSSID()).thenAnswer((_) async => 'random-old-ssid');
+      when(mockHotspotProvisioningRepository.connectToSecureNetworkByPrefix(
+        prefix: anyNamed('prefix'),
+        password: anyNamed('password'),
+        isWep: anyNamed('isWep'),
+        isWpa3: anyNamed('isWpa3'),
+        saveNetwork: anyNamed('saveNetwork'),
+      )).thenAnswer((_) async => true);
+      when(mockHotspotProvisioningRepository.isDeviceReachable()).thenAnswer((_) async => true);
+
+      connectHotspotPrefixViewModel.connectToHotspot();
+
+      // Wait for async operations to complete
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      verify(mockHotspotProvisioningRepository.isDeviceReachable()).called(1);
+      expect(connectHotspotPrefixViewModel.connectedToHotspot, isTrue);
+      expect(connectHotspotPrefixViewModel.pollingForMachine, isTrue);
+    });
+
+    test('should fail normally when prefix join fails and device is not reachable', () async {
+      when(mockHotspotProvisioningRepository.getCurrentSSID()).thenAnswer((_) async => 'random-old-ssid');
+      when(mockHotspotProvisioningRepository.connectToSecureNetworkByPrefix(
+        prefix: anyNamed('prefix'),
+        password: anyNamed('password'),
+        isWep: anyNamed('isWep'),
+        isWpa3: anyNamed('isWpa3'),
+        saveNetwork: anyNamed('saveNetwork'),
+      )).thenAnswer((_) async => false);
+      when(mockHotspotProvisioningRepository.isDeviceReachable()).thenAnswer((_) async => false);
+
+      connectHotspotPrefixViewModel.connectToHotspot();
+
+      // Wait for async operations to complete
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      verify(mockHotspotProvisioningRepository.isDeviceReachable()).called(1);
+      expect(connectHotspotPrefixViewModel.connectedToHotspot, isFalse);
+      expect(connectHotspotPrefixViewModel.pollingForMachine, isFalse);
+
+      if (Platform.isIOS) {
+        expect(connectHotspotPrefixViewModel.failedToConnectToHotspot, isTrue);
+      } else {
         expect(connectHotspotPrefixViewModel.failedToConnectToHotspot, isFalse);
       }
     });

--- a/test/screens/connect_hotspot_prefix/widgets/connect_hotspot_prefix_screen_test.dart
+++ b/test/screens/connect_hotspot_prefix/widgets/connect_hotspot_prefix_screen_test.dart
@@ -23,6 +23,7 @@ void main() {
       repository: mockRepository,
     );
     when(mockRepository.disconnect()).thenAnswer((_) async => true);
+    when(mockRepository.isDeviceReachable()).thenAnswer((_) async => false);
   });
 
   Widget connectHotspotPrefixScreenWidget() {


### PR DESCRIPTION
When auto-joining the device hotspot by prefix fails, check whether the device's provisioning service is already reachable on the current network before failing. This lets users provision older devices with randomized SSIDs by joining the network manually.



### QA Checklist  
[View QA Test Doc](https://docs.google.com/spreadsheets/d/184MDRbFp_EWAj7St7X4Yh51t2pJyAvTcM48qr9BTKnE/edit?gid=748601322#gid=748601322)

Please confirm the following before requesting review:

- [] I have verified this change against all relevant tasks in the QA doc.  
- [] If this PR adds a new feature or bug fix, I have added or updated the corresponding test cases in the QA doc.

No edit access to QA Doc