### PR TITLE
Migrate publish job off BuildJet runner

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for authentication using OIDC
     steps:


### PR DESCRIPTION
## What

Moves the `publish` job in `.github/workflows/publish.yaml` from `buildjet-2vcpu-ubuntu-2204` to `ubuntu-latest`.

## Why

This job was the **last remaining BuildJet reference** across the `viamrobotics`, `viam-modules`, and `viam-labs` orgs — found while auditing all 568 non-archived repos for BuildJet usage. Everything else has already been migrated to `ubuntu-large` / `github-linux-arm64-8core`.

## Why `ubuntu-latest`

`release.yaml` in this repo already runs on `ubuntu-latest` on the identical `v*` tag trigger, so this follows existing convention for tag-triggered jobs here. `ubuntu-large` is reserved for the containerized `test.yaml` job and would be overkill — `publish` only runs `flutter pub get` and `dart pub publish`. This repo is public, so `ubuntu-latest` provides 4 vCPU, more than the 2 vCPU BuildJet runner it replaces.

## Note

This bumps the runner OS from Ubuntu 22.04 to 24.04 (whatever `ubuntu-latest` currently points at). The job installs Flutter/Dart via `subosito/flutter-action` and `dart-lang/setup-dart` rather than relying on anything preinstalled in the image, so it shouldn't be sensitive to the OS version. If you'd rather hold the pin, `ubuntu-22.04` is a one-word change.

## Testing

`publish.yaml` is tag-triggered only, so it won't run on this PR. The change is a single `runs-on` value; YAML parses and the job definition is otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)